### PR TITLE
chore(deps): Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -69,10 +69,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -161,10 +161,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -205,10 +205,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -221,9 +221,9 @@ jobs:
           pytest tests/ -v --cov=adversarial_workflow --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
           verbose: true
         env:


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` from v4 to v6
- Bump `actions/setup-python` from v5 to v6
- Bump `codecov/codecov-action` from v4 to v5
- **Fix breaking change**: `file` parameter renamed to `files` in codecov v5

This PR combines and supersedes the following dependabot PRs:
- #2 - actions/checkout v4 → v6
- #3 - actions/setup-python v5 → v6
- #4 - codecov/codecov-action v4 → v5

### Why combine?

The codecov v5 upgrade has a breaking change (`file` → `files` parameter) that dependabot cannot automatically fix. Creating a combined PR ensures:
1. All changes are tested together
2. The breaking change fix is included
3. CI passes before merging

## Test plan

- [ ] CI workflow runs successfully with updated actions
- [ ] Coverage reports upload correctly to Codecov
- [ ] All test jobs pass (installation, workflow, bash-compatibility, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)