### PR TITLE
fix: Disable URL auto-scraping during evaluations

### DIFF
--- a/.adversarial/scripts/evaluate_plan.sh
+++ b/.adversarial/scripts/evaluate_plan.sh
@@ -56,6 +56,7 @@ mkdir -p "$LOG_DIR"
 aider \
   --model "$EVALUATOR_MODEL" \
   --yes \
+  --no-detect-urls \
   --no-git \
   --map-tokens 0 \
   --no-gitignore \

--- a/.adversarial/scripts/review_implementation.sh
+++ b/.adversarial/scripts/review_implementation.sh
@@ -99,6 +99,7 @@ fi
 aider \
   --model "$EVALUATOR_MODEL" \
   --yes \
+  --no-detect-urls \
   --no-gitignore \
   --read $READ_FILES \
   --message "You are a REVIEWER performing critical code review.

--- a/.adversarial/scripts/validate_tests.sh
+++ b/.adversarial/scripts/validate_tests.sh
@@ -86,6 +86,7 @@ echo ""
 aider \
   --model "$EVALUATOR_MODEL" \
   --yes \
+  --no-detect-urls \
   --no-gitignore \
   --read "$TASK_FILE" "${ARTIFACTS_DIR}${TASK_NUM}-final-implementation.diff" "${ARTIFACTS_DIR}${TASK_NUM}-test-output.txt" \
   --message "You are a REVIEWER performing test validation and analysis.


### PR DESCRIPTION
## Summary

- **Add `--no-detect-urls` flag** to all aider invocations in evaluation scripts
- **Prevents unwanted URL scraping** when task files contain URLs (documentation links, API references, etc.)
- **No impact on direct aider usage** - only affects adversarial-workflow evaluation phases

## Problem

When running evaluations in non-interactive mode:
1. The `--yes` flag auto-confirms all prompts, including URL scraping
2. Task files often contain URLs (e.g., `https://docs.mistral.ai/`)
3. Aider would automatically detect and scrape these URLs
4. This caused timeouts, unexpected behavior, and wasted API tokens

## Solution

Add `--no-detect-urls` after `--yes` in all evaluation scripts:
- `evaluate_plan.sh` (Phase 1)
- `review_implementation.sh` (Phase 3)
- `validate_tests.sh` (Phase 4)

## Testing

Verified fix with:
```bash
echo "Content with URL: https://example.com" | \
  aider --no-detect-urls --yes --no-git --model gpt-4o-mini \
  --message "Say OK"
# Result: No URL scraping, model responds normally
```

## References

- [Aider Options Reference](https://aider.chat/docs/config/options.html)
- [GitHub Issue #2187](https://github.com/Aider-AI/aider/issues/2187) - Original feature request for scraping control

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes CLI flags in evaluation scripts; minimal runtime impact aside from preventing unintended network/URL scraping behavior.
> 
> **Overview**
> Disables aider’s URL auto-detection/scraping during adversarial evaluation runs by adding `--no-detect-urls` to the `aider` invocations in `evaluate_plan.sh`, `review_implementation.sh`, and `validate_tests.sh`, preventing non-interactive (`--yes`) runs from fetching URLs embedded in task/artifact files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9081bc7f31caf4888a4d9af08378a41855a2e374. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->