### PR TITLE
fix: Add EVALUATOR_MODEL fallback in legacy shell scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.8] - 2026-02-11
+
+### Fixed
+
+- **Legacy script EVALUATOR_MODEL fallback** - Shell script templates now include `${EVALUATOR_MODEL:-gpt-4o}` fallback. Users who removed the deprecated `evaluator_model` field from `config.yml` no longer get empty model errors when running legacy scripts directly.
+
 ## [0.9.7] - 2026-02-10
 
 ### Added

--- a/adversarial_workflow/__init__.py
+++ b/adversarial_workflow/__init__.py
@@ -16,7 +16,7 @@ try:
     from importlib.metadata import version as _get_version
     __version__ = _get_version("adversarial-workflow")
 except Exception:
-    __version__ = "0.9.7"  # Fallback for editable installs
+    __version__ = "0.9.8"  # Fallback for editable installs
 __author__ = "Fredrik Matheson"
 __license__ = "MIT"
 

--- a/adversarial_workflow/templates/evaluate_plan.sh.template
+++ b/adversarial_workflow/templates/evaluate_plan.sh.template
@@ -68,7 +68,9 @@ if [ ! -f .adversarial/config.yml ]; then
 fi
 
 # Parse config using grep/awk (simple YAML parsing)
-EVALUATOR_MODEL=$(grep 'evaluator_model:' .adversarial/config.yml | awk '{print $2}')
+# Note: evaluator_model is deprecated. Consider using 'adversarial evaluate' CLI instead.
+EVALUATOR_MODEL=$(grep 'evaluator_model:' .adversarial/config.yml 2>/dev/null | awk '{print $2}')
+EVALUATOR_MODEL=${EVALUATOR_MODEL:-gpt-4o}  # Default fallback if not configured
 TASK_DIR=$(grep 'task_directory:' .adversarial/config.yml | awk '{print $2}')
 LOG_DIR=$(grep 'log_directory:' .adversarial/config.yml | awk '{print $2}')
 

--- a/adversarial_workflow/templates/proofread_content.sh.template
+++ b/adversarial_workflow/templates/proofread_content.sh.template
@@ -68,7 +68,9 @@ if [ ! -f .adversarial/config.yml ]; then
 fi
 
 # Parse config using grep/awk (simple YAML parsing)
-EVALUATOR_MODEL=$(grep 'evaluator_model:' .adversarial/config.yml | awk '{print $2}')
+# Note: evaluator_model is deprecated. Consider using 'adversarial evaluate' CLI instead.
+EVALUATOR_MODEL=$(grep 'evaluator_model:' .adversarial/config.yml 2>/dev/null | awk '{print $2}')
+EVALUATOR_MODEL=${EVALUATOR_MODEL:-gpt-4o}  # Default fallback if not configured
 LOG_DIR=$(grep 'log_directory:' .adversarial/config.yml | awk '{print $2}')
 
 DOC_FILE="$1"

--- a/adversarial_workflow/templates/review_implementation.sh.template
+++ b/adversarial_workflow/templates/review_implementation.sh.template
@@ -67,8 +67,10 @@ if [ ! -f .adversarial/config.yml ]; then
   exit 1
 fi
 
-# Parse config
-EVALUATOR_MODEL=$(grep 'evaluator_model:' .adversarial/config.yml | awk '{print $2}')
+# Parse config using grep/awk (simple YAML parsing)
+# Note: evaluator_model is deprecated. Consider using 'adversarial evaluate' CLI instead.
+EVALUATOR_MODEL=$(grep 'evaluator_model:' .adversarial/config.yml 2>/dev/null | awk '{print $2}')
+EVALUATOR_MODEL=${EVALUATOR_MODEL:-gpt-4o}  # Default fallback if not configured
 TASK_DIR=$(grep 'task_directory:' .adversarial/config.yml | awk '{print $2}')
 LOG_DIR=$(grep 'log_directory:' .adversarial/config.yml | awk '{print $2}')
 ARTIFACTS_DIR=$(grep 'artifacts_directory:' .adversarial/config.yml | awk '{print $2}')

--- a/adversarial_workflow/templates/validate_tests.sh.template
+++ b/adversarial_workflow/templates/validate_tests.sh.template
@@ -67,8 +67,10 @@ if [ ! -f .adversarial/config.yml ]; then
   exit 1
 fi
 
-# Parse config
-EVALUATOR_MODEL=$(grep 'evaluator_model:' .adversarial/config.yml | awk '{print $2}')
+# Parse config using grep/awk (simple YAML parsing)
+# Note: evaluator_model is deprecated. Consider using 'adversarial evaluate' CLI instead.
+EVALUATOR_MODEL=$(grep 'evaluator_model:' .adversarial/config.yml 2>/dev/null | awk '{print $2}')
+EVALUATOR_MODEL=${EVALUATOR_MODEL:-gpt-4o}  # Default fallback if not configured
 TASK_DIR=$(grep 'task_directory:' .adversarial/config.yml | awk '{print $2}')
 LOG_DIR=$(grep 'log_directory:' .adversarial/config.yml | awk '{print $2}')
 ARTIFACTS_DIR=$(grep 'artifacts_directory:' .adversarial/config.yml | awk '{print $2}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "adversarial-workflow"
 
-version = "0.9.7"
+version = "0.9.8"
 
 description = "Multi-stage AI evaluation system for task plans, code review, and test validation"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Adds `${EVALUATOR_MODEL:-gpt-4o}` fallback to all 4 shell script templates
- Users who removed the deprecated `evaluator_model` field from config.yml no longer get empty model errors
- Includes deprecation note comments in templates

## Test plan
- [x] All 485 tests pass (1 version test fails due to local env mismatch - unrelated)
- [ ] Manual verification: run `adversarial init --force` then remove `evaluator_model` from config.yml, run scripts directly

## Files Changed
- `adversarial_workflow/templates/evaluate_plan.sh.template`
- `adversarial_workflow/templates/validate_tests.sh.template`
- `adversarial_workflow/templates/review_implementation.sh.template`
- `adversarial_workflow/templates/proofread_content.sh.template`
- `pyproject.toml` - version bump to 0.9.8
- `adversarial_workflow/__init__.py` - fallback version to 0.9.8
- `CHANGELOG.md` - v0.9.8 release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to template scripts and version metadata; primary risk is unintended model selection defaults when users relied on an empty/invalid config value.
> 
> **Overview**
> Adds a safe default for legacy script execution by making all shipped shell script templates fall back to `gpt-4o` when `evaluator_model` is missing from `.adversarial/config.yml`, and annotates this config key as deprecated.
> 
> Bumps the package version to `0.9.8` (including editable-install fallback) and records the fix in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a6774625a05bf5078d012cc850c26bc78508baa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->