### PR TITLE
fix: Strip trailing .md from output_suffix to prevent double extension

### DIFF
--- a/adversarial_workflow/evaluators/runner.py
+++ b/adversarial_workflow/evaluators/runner.py
@@ -22,6 +22,13 @@ from .config import EvaluatorConfig
 from .resolver import ModelResolver, ResolutionError
 
 
+def _normalize_output_suffix(output_suffix: str) -> str:
+    """Strip trailing .md extension from output suffix to avoid double extensions."""
+    if output_suffix.lower().endswith(".md"):
+        return output_suffix[:-3]
+    return output_suffix
+
+
 def run_evaluator(config: EvaluatorConfig, file_path: str, timeout: int = 180) -> int:
     """Run an evaluator on a file.
 
@@ -129,7 +136,7 @@ def _run_custom_evaluator(
     logs_dir.mkdir(parents=True, exist_ok=True)
 
     file_basename = Path(file_path).stem
-    suffix = config.output_suffix.removesuffix(".md")
+    suffix = _normalize_output_suffix(config.output_suffix)
     output_file = logs_dir / f"{file_basename}-{suffix}.md"
 
     # Read input file
@@ -253,7 +260,7 @@ def _execute_script(
 
     # Validate output
     file_basename = Path(file_path).stem
-    suffix = config.output_suffix.removesuffix(".md")
+    suffix = _normalize_output_suffix(config.output_suffix)
     log_file = Path(project_config["log_directory"]) / f"{file_basename}-{suffix}.md"
 
     is_valid, verdict, message = validate_evaluation_output(str(log_file))

--- a/tests/test_evaluator_runner.py
+++ b/tests/test_evaluator_runner.py
@@ -11,6 +11,8 @@ from adversarial_workflow.evaluators.config import EvaluatorConfig, ModelRequire
 from adversarial_workflow.evaluators.resolver import ModelResolver, ResolutionError
 from adversarial_workflow.evaluators.runner import (
     _check_file_size,
+    _execute_script,
+    _normalize_output_suffix,
     _report_verdict,
     run_evaluator,
 )
@@ -545,6 +547,58 @@ class TestOutputFilenameExtension:
             assert len(written_files) == 1
             assert written_files[0].name == "task-spec--arch-review.md"
             assert not written_files[0].name.endswith(".md.md")
+
+    def test_builtin_suffix_with_md_extension_no_double(self, tmp_path):
+        """Built-in _execute_script path also normalizes suffix."""
+        test_file = tmp_path / "task-spec.md"
+        test_file.write_text("# Test")
+
+        logs_dir = tmp_path / ".adversarial" / "logs"
+        logs_dir.mkdir(parents=True)
+
+        # Pre-create the expected log file (script would normally write it)
+        # Validator requires 500+ bytes
+        expected_log = logs_dir / "task-spec-PLAN-EVAL.md"
+        expected_log.write_text("## Verdict: APPROVED\n\n" + "Evaluation details. " * 30)
+
+        config = EvaluatorConfig(
+            name="evaluate",
+            description="Plan evaluation",
+            model="gpt-4o",
+            api_key_env="OPENAI_API_KEY",
+            prompt="",
+            output_suffix="PLAN-EVAL.md",
+            source="builtin",
+        )
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+            result = _execute_script(
+                "/fake/script.sh",
+                str(test_file),
+                config,
+                {"log_directory": str(logs_dir)},
+                30,
+            )
+
+        assert result == 0
+        assert expected_log.exists()
+        assert not (logs_dir / "task-spec-PLAN-EVAL.md.md").exists()
+
+    def test_normalize_output_suffix_lowercase(self):
+        """Helper strips lowercase .md."""
+        assert _normalize_output_suffix("-arch-review.md") == "-arch-review"
+
+    def test_normalize_output_suffix_uppercase(self):
+        """Helper strips uppercase .MD."""
+        assert _normalize_output_suffix("-arch-review.MD") == "-arch-review"
+
+    def test_normalize_output_suffix_mixed_case(self):
+        """Helper strips mixed-case .Md."""
+        assert _normalize_output_suffix("-arch-review.Md") == "-arch-review"
+
+    def test_normalize_output_suffix_no_extension(self):
+        """Helper leaves suffix without .md unchanged."""
+        assert _normalize_output_suffix("TEST-EVAL") == "TEST-EVAL"
 
 
 class TestAiderCommandFlags:


### PR DESCRIPTION
## Summary

- Fixes double `.md.md` extension in evaluator output filenames when library evaluator YAML configs define `output_suffix` ending in `.md`
- Uses `removesuffix(".md")` to normalize the suffix in both `_run_custom_evaluator` and `_execute_script` code paths
- Adds 2 regression tests covering suffixes with and without `.md`

Closes #30

## Test plan

- [x] All 488 existing tests pass
- [x] New test: suffix without `.md` → single `.md` extension
- [x] New test: suffix with `.md` → no `.md.md` double extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized string/filename normalization change with targeted tests; minimal risk beyond slight behavior change for configs that previously relied on the double-extension bug.
> 
> **Overview**
> Fixes an output naming bug where evaluator logs could be written as `*.md.md` when `output_suffix` already ended with `.md`.
> 
> Adds `_normalize_output_suffix()` and applies it in both the custom evaluator output writer and the builtin `_execute_script` validation path, and introduces regression tests covering suffixes with/without `.md` (including case variants).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2afb75fbbb5560673b6da95141fa6686f5801272. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->