### PR TITLE
feat: Auto-detect preflight --type from task spec (ADV-0062)

### DIFF
--- a/delegation/tasks/3-in-progress/ADV-0062-preflight-auto-type-from-task-spec.md
+++ b/delegation/tasks/3-in-progress/ADV-0062-preflight-auto-type-from-task-spec.md
@@ -1,6 +1,6 @@
 # ADV-0062: Preflight Auto-Detection from Task Spec Type Field
 
-**Status**: Backlog
+**Status**: In Progress
 **Priority**: Low
 **Type**: Enhancement
 **Estimated Effort**: 30 minutes

--- a/scripts/core/preflight-check.sh
+++ b/scripts/core/preflight-check.sh
@@ -38,8 +38,8 @@ while [[ $# -gt 0 ]]; do
             echo "  code    All 7 gates checked (feature/bug-fix tasks)"
             echo "  docs    Gates 1, 5, 6 skipped (documentation-only tasks)"
             echo "  sync    Gates 5, 6 skipped; gate 1 auto-skips if no code changes"
-            echo "  (auto)  If --type is omitted, auto-detects from changed files:"
-            echo "          no code changes = docs, otherwise = code"
+            echo "  (auto)  If --type is omitted, auto-detects from task spec **Type** field,"
+            echo "          then falls back to changed files: no code changes = docs, otherwise = code"
             echo ""
             echo "Gates:"
             echo "  1. CI green                    GitHub Actions passing"
@@ -141,6 +141,21 @@ if [ -z "$TASK_ID" ]; then
         echo "ERROR:Could not derive task ID from branch '$BRANCH'"
         echo "Use --task TASK_ID to specify manually."
         exit 1
+    fi
+fi
+
+# ─── Auto-detect task type from task spec ────────────────────────────
+# Priority: explicit --type > task spec **Type** field > code-changes heuristic
+if [ -z "$TASK_TYPE" ]; then
+    TASK_FILE_FOR_TYPE=$(find delegation/tasks -name "${TASK_ID}-*" -o -name "${TASK_ID}.*" 2>/dev/null | head -1 || true)
+    if [ -n "$TASK_FILE_FOR_TYPE" ]; then
+        SPEC_TYPE=$(grep '^\*\*Type\*\*:' "$TASK_FILE_FOR_TYPE" | sed 's/.*: *//')
+        case "$SPEC_TYPE" in
+            "Upstream Sync") TASK_TYPE="sync" ;;
+            "Documentation") TASK_TYPE="docs" ;;
+            # All other values (Enhancement, Bug Fix, etc.) fall through
+            # to the code-changes heuristic below
+        esac
     fi
 fi
 

--- a/tests/test_preflight_auto_type.py
+++ b/tests/test_preflight_auto_type.py
@@ -1,0 +1,87 @@
+"""Tests for preflight-check.sh auto-type detection from task spec.
+
+Tests the logic that reads **Type** from task spec frontmatter and maps it
+to preflight modes (sync, docs), with explicit --type always winning.
+"""
+
+import os
+import subprocess
+import tempfile
+
+# The bash snippet under test — mirrors the auto-detect block in preflight-check.sh
+AUTO_TYPE_SNIPPET = r"""
+TASK_TYPE="$1"
+TASK_FILE="$2"
+
+if [ -z "$TASK_TYPE" ] && [ -n "$TASK_FILE" ]; then
+    SPEC_TYPE=$(grep '^\*\*Type\*\*:' "$TASK_FILE" | sed 's/.*: *//')
+    case "$SPEC_TYPE" in
+        "Upstream Sync") TASK_TYPE="sync" ;;
+        "Documentation") TASK_TYPE="docs" ;;
+    esac
+fi
+
+echo "$TASK_TYPE"
+"""
+
+
+def _run_auto_type(task_type: str, task_file_content: str | None) -> str:
+    """Run the auto-type bash snippet and return the resulting TASK_TYPE."""
+    file_path = ""
+    tmp_path = None
+    try:
+        if task_file_content is not None:
+            fd, tmp_path = tempfile.mkstemp(suffix=".md")
+            with os.fdopen(fd, "w") as f:
+                f.write(task_file_content)
+            file_path = tmp_path
+
+        result = subprocess.run(
+            ["bash", "-c", AUTO_TYPE_SNIPPET, "--", task_type, file_path],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip()
+    finally:
+        if tmp_path is not None:
+            os.unlink(tmp_path)
+
+
+class TestPreflightAutoType:
+    """Test auto-type detection from task spec **Type** field."""
+
+    def test_auto_detect_upstream_sync(self):
+        """Task with **Type**: Upstream Sync maps to sync mode."""
+        result = _run_auto_type("", "# ADV-9999\n\n**Status**: Todo\n**Type**: Upstream Sync\n")
+        assert result == "sync"
+
+    def test_auto_detect_documentation(self):
+        """Task with **Type**: Documentation maps to docs mode."""
+        result = _run_auto_type("", "# ADV-9999\n\n**Status**: Todo\n**Type**: Documentation\n")
+        assert result == "docs"
+
+    def test_explicit_type_overrides_spec(self):
+        """Explicit --type flag overrides task spec auto-detection."""
+        result = _run_auto_type("code", "# ADV-9999\n\n**Type**: Upstream Sync\n")
+        assert result == "code"
+
+    def test_unmapped_type_falls_through(self):
+        """Unmapped type values (Enhancement, Bug Fix) leave TASK_TYPE empty."""
+        result = _run_auto_type("", "# ADV-9999\n\n**Type**: Enhancement\n")
+        assert result == ""
+
+    def test_bug_fix_falls_through(self):
+        """Bug Fix type falls through to code-changes heuristic."""
+        result = _run_auto_type("", "# ADV-9999\n\n**Type**: Bug Fix\n")
+        assert result == ""
+
+    def test_no_task_file(self):
+        """No task file found — TASK_TYPE stays empty for heuristic."""
+        result = _run_auto_type("", None)
+        assert result == ""
+
+    def test_no_type_field_in_spec(self):
+        """Task file exists but has no **Type** field — falls through."""
+        result = _run_auto_type("", "# ADV-9999\n\n**Status**: Todo\n")
+        assert result == ""

--- a/tests/test_preflight_auto_type.py
+++ b/tests/test_preflight_auto_type.py
@@ -42,6 +42,7 @@ def _run_auto_type(task_type: str, task_file_content: str | None) -> str:
             text=True,
             timeout=5,
         )
+        assert result.returncode == 0, result.stderr
         return result.stdout.strip()
     finally:
         if tmp_path is not None:


### PR DESCRIPTION
## Summary

- Reads `**Type**` from the task spec when `--type` is not provided, mapping `Upstream Sync` → `sync` and `Documentation` → `docs`
- Explicit `--type` flag always wins; unmapped values (Enhancement, Bug Fix, etc.) fall through to the existing code-changes heuristic
- 7 test cases covering auto-detect, override, fallthrough, and edge cases

## Test plan

- [x] `pytest tests/test_preflight_auto_type.py -v` — 7/7 pass
- [x] `./scripts/core/ci-check.sh` — all 500 tests pass, lint clean
- [ ] CI green on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preflight mode selection, which can alter which merge gates are skipped/run based on task metadata; logic is small and covered by focused tests but impacts release hygiene if mis-detected.
> 
> **Overview**
> `preflight-check.sh` now auto-detects `--type` by reading the task spec’s `**Type**` field (mapping `Upstream Sync` → `sync`, `Documentation` → `docs`) before falling back to the existing “code changes vs no code changes” heuristic, and updates the `--help` text accordingly.
> 
> Adds Python tests covering the mapping, explicit `--type` override, and fallthrough edge cases, and marks the ADV-0062 task as In Progress.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d341e2905d665a8aa1aa2b2ebb530386f27dbe99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->