### PR TITLE
ADV-0035: runner.py test coverage 72% → 100%

### DIFF
--- a/.agent-context/ADV-0035-HANDOFF-feature-developer.md
+++ b/.agent-context/ADV-0035-HANDOFF-feature-developer.md
@@ -1,0 +1,87 @@
+# ADV-0035: Evaluator Runner Test Coverage - Implementation Handoff
+
+**You are the feature-developer. Implement this task directly. Do not delegate or spawn other agents.**
+
+**Date**: 2026-03-19
+**From**: Planner
+**To**: feature-developer-v3
+**Task**: delegation/tasks/2-todo/ADV-0035-evaluator-runner-test-coverage.md
+**Status**: Ready for implementation
+**Evaluation**: N/A (well-scoped testing task, no architectural risk)
+
+---
+
+## Task Summary
+
+Increase test coverage for `adversarial_workflow/evaluators/runner.py` from 72% to 85%+. The module has 172 statements with 49 missing lines, mostly in error handling paths. There are currently 30 tests in 4 classes.
+
+## Current Situation
+
+The evaluator runner is the core execution engine — it shells out to `aider` to run evaluations. The happy paths are well-tested, but error handling (aider not found, subprocess failures, timeouts, output validation) has gaps. These are the paths that fail silently or with unhelpful errors in production.
+
+## Your Mission
+
+Write tests for the uncovered error paths in `runner.py`. This is a pure testing task — **do not modify `runner.py` itself** (unless a test reveals an actual bug).
+
+### Phase 1: Read and Understand (15 min)
+- Read `adversarial_workflow/evaluators/runner.py` (354 lines)
+- Read existing `tests/test_evaluator_runner.py` (30 tests)
+- Understand the mocking patterns already in use
+
+### Phase 2: Write Tests (2-3h)
+- Extend `tests/test_evaluator_runner.py` with new test classes/methods
+- Target the specific missing lines listed below
+- Follow existing test patterns and fixtures
+
+### Phase 3: Verify (15 min)
+- Run coverage: `.venv/bin/python -m pytest tests/test_evaluator_runner.py --cov=adversarial_workflow.evaluators.runner --cov-report=term-missing -q`
+- Verify 85%+ achieved
+- Run full suite: `.venv/bin/python -m pytest tests/ -q`
+
+## Missing Lines to Cover
+
+| Lines | Description | Priority | Suggested Test |
+|-------|-------------|----------|----------------|
+| 83-86, 90 | Aider binary not found | High | Mock `shutil.which` returning `None` |
+| 102-114 | Subprocess errors (CalledProcessError, OSError) | High | Mock `subprocess.run` raising exceptions |
+| 193-194 | Edge case in evaluator resolution | Low | Test with unusual evaluator config |
+| 219-226 | Edge case in command building | Low | Test with edge-case parameters |
+| 250-258, 268-269 | Output file validation failures | Medium | Test with empty/missing/corrupt output files |
+| 312-315, 320-321 | Error reporting paths | Medium | Test with various error conditions |
+| 334-339, 344, 349-354 | Timeout and cleanup | Medium | Mock subprocess timeout, verify cleanup |
+
+## Key Mocking Patterns
+
+The existing tests use `unittest.mock` (via `mocker` fixture from pytest-mock). Key things to mock:
+
+```python
+# Aider binary detection
+mocker.patch('shutil.which', return_value=None)  # aider not found
+
+# Subprocess execution
+mocker.patch('subprocess.run', side_effect=subprocess.CalledProcessError(1, 'aider'))
+mocker.patch('subprocess.run', side_effect=subprocess.TimeoutExpired('aider', 300))
+
+# File system for output validation
+# Use tmp_path fixture for creating test output files
+```
+
+## Defensive Coding Rules
+
+- Check `.agent-context/patterns.yml` before writing code
+- Use `==` for identifier comparison (DK002)
+- Use `str.removesuffix()` for extension removal (DK003)
+- Run `python3 scripts/core/pattern_lint.py` on any modified files
+
+## Success Criteria
+
+- `runner.py` coverage reaches **85%+** (currently 72%, need to cover ~22 more lines)
+- All 500+ existing tests still pass
+- New tests follow existing patterns and naming conventions
+- No modifications to `runner.py` (tests only, unless bug found)
+
+---
+
+**Task File**: `delegation/tasks/2-todo/ADV-0035-evaluator-runner-test-coverage.md`
+**Handoff Date**: 2026-03-19
+**Coordinator**: Planner

--- a/.agent-context/ADV-0035-REVIEW-STARTER.md
+++ b/.agent-context/ADV-0035-REVIEW-STARTER.md
@@ -1,0 +1,47 @@
+# Review Starter: ADV-0035
+
+**Task**: ADV-0035 — Evaluator Runner Test Coverage
+**Task File**: `delegation/tasks/4-in-review/ADV-0035-evaluator-runner-test-coverage.md`
+**Branch**: `feature/ADV-0035-runner-test-coverage` → `main`
+**PR**: https://github.com/movito/adversarial-workflow/pull/55
+
+## Implementation Summary
+
+- Raised `adversarial_workflow/evaluators/runner.py` test coverage from 72% → **100%** (172/172 statements)
+- Added 8 new test classes and ~550 lines of tests to `tests/test_evaluator_runner.py`
+- Zero modifications to `runner.py` — tests only, as specified
+- All 73 tests in the file pass; full suite (500+) has zero regressions
+
+## Files Changed
+
+- `tests/test_evaluator_runner.py` (modified — 8 new test classes appended)
+
+## Test Results
+
+- **73 tests passing** (up from 30)
+- **100% coverage** (`runner.py` 172/172 statements)
+- Full suite: 500+ tests, 0 failures
+
+## Automated Review Summary
+
+- **BugBot**: 1 thread — `test_prompt_file_cleaned_up_after_timeout` had no assertions → renamed to `test_timeout_exception_does_not_propagate` + added `assert result == 1`. Resolved.
+- **CodeRabbit (round 1)**: 3 trivial/nitpick threads — return-value assertion, minor test overlap, and non-Windows output assertion strength. All fixed or resolved with justification.
+- **CodeRabbit (round 2)**: 2 threads — Major: routing assertion too weak (fixed by mocking `_run_builtin_evaluator` directly); Minor: delegation assertion missing (fixed by patching `_execute_script` + `assert_called_once()`). Both fixed in b54eadd.
+- **Code-review evaluator**: Skipped — zero lines of source changed (auto-skip criteria met)
+
+## Areas for Review Focus
+
+- **New test classes** (lines 636–1200 of `tests/test_evaluator_runner.py`): 8 classes covering large-file handling, warn functions, confirm-continue, builtin/custom routing, execute-script errors, helper print functions, and all verdict types
+- **Coverage quality**: every `isinstance` guard and error path in `runner.py` has a corresponding test — not just line coverage
+- **Mocking discipline**: tests use the most-specific mock target (module-qualified paths like `adversarial_workflow.evaluators.runner._execute_script` rather than `subprocess.run`) after bot review
+
+## Related ADRs
+
+- None — this is a pure test coverage task
+
+---
+
+**Ready for human review**
+
+Threads: 6/6 resolved, 0 unresolved
+HEAD: b54eadd

--- a/.agent-context/ADV-0057-HANDOFF-feature-developer.md
+++ b/.agent-context/ADV-0057-HANDOFF-feature-developer.md
@@ -1,0 +1,98 @@
+# ADV-0057: Review Script Robustness - Implementation Handoff
+
+**You are the feature-developer. Implement this task directly. Do not delegate or spawn other agents.**
+
+**Date**: 2026-03-19
+**From**: Planner
+**To**: feature-developer-v3
+**Task**: delegation/tasks/2-todo/ADV-0057-review-script-robustness.md
+**Status**: Ready for implementation
+**Evaluation**: N/A (small hardening task, 4 specific fixes)
+
+---
+
+## Task Summary
+
+Fix 4 robustness gaps in `review_implementation.sh` and its CLI wrapper, identified by the adversarial code-review evaluator during ADV-0054. All are pre-existing edge cases, not regressions.
+
+## Current Situation
+
+The review script (`review_implementation.sh`) and its template work fine in normal conditions but fail ungracefully when:
+1. Config is missing `artifacts_directory` or `log_directory`
+2. The repo uses `master` instead of `main` and `origin/HEAD` isn't set
+3. `git diff base...HEAD` fails with invalid refs
+4. Script is invoked directly with empty `TASK_FILE`
+
+These were found by the Gemini Flash code-reviewer during ADV-0054 review.
+
+## Your Mission
+
+Apply 4 targeted fixes across 3 files. Each fix is small and independent.
+
+### Fix 1: Default config variables (Medium risk)
+**Files**: `.adversarial/scripts/review_implementation.sh` + template
+**Change**: Add default values after config parsing:
+```bash
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-.adversarial/artifacts/}
+LOG_DIR=${LOG_DIR:-.adversarial/logs/}
+```
+
+### Fix 2: Validate default branch ref exists (Low risk)
+**Files**: `.adversarial/scripts/review_implementation.sh` + template
+**Change**: After determining `DEFAULT_BRANCH`, verify it exists:
+```bash
+if ! git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  echo "Error: Cannot find base branch '$DEFAULT_BRANCH'. Set origin/HEAD or pass branch explicitly."
+  exit 1
+fi
+```
+
+### Fix 3: CLI pre-check error handling (Low risk)
+**Files**: `adversarial_workflow/cli.py` (the `review()` function, around line 2157)
+**Change**: Check `branch_diff.returncode` for values > 1 (git error vs. changes detected) and report clearly before invoking the script.
+
+### Fix 4: Empty task_file validation (Low risk)
+**Files**: `.adversarial/scripts/review_implementation.sh` + template
+**Change**: Add early validation:
+```bash
+if [ -z "$TASK_FILE" ] || [ ! -f "$TASK_FILE" ]; then
+  echo "Error: Task file not found or not specified: $TASK_FILE"
+  exit 1
+fi
+```
+
+## Critical Details
+
+### Template sync is mandatory
+The script at `.adversarial/scripts/review_implementation.sh` and the template at `adversarial_workflow/templates/review_implementation.sh.template` **must stay in sync**. Apply identical changes to both files.
+
+### Files to modify
+1. `.adversarial/scripts/review_implementation.sh` — fixes 1, 2, 4
+2. `adversarial_workflow/templates/review_implementation.sh.template` — same fixes 1, 2, 4
+3. `adversarial_workflow/cli.py` — fix 3 (review function ~line 2157)
+
+### Testing
+- All 500 existing tests must pass
+- Add tests for fix 3 (CLI error handling) if feasible
+- Shell script fixes are harder to unit test — manual verification is acceptable
+
+## Defensive Coding Rules
+
+- Check `.agent-context/patterns.yml` before writing code
+- Use `==` for identifier comparison (DK002)
+- Run `python3 scripts/core/pattern_lint.py` on any modified `.py` files
+- Run `.venv/bin/python -m pytest tests/ -q` to verify no regressions
+
+## Success Criteria
+
+- All 4 edge cases handled gracefully with clear error messages
+- Template and committed script remain in sync
+- All existing tests pass
+- No unrelated changes
+
+---
+
+**Task File**: `delegation/tasks/2-todo/ADV-0057-review-script-robustness.md`
+**Evaluator Review**: `.agent-context/reviews/ADV-0054-code-reviewer-fast.md`
+**Handoff Date**: 2026-03-19
+**Coordinator**: Planner

--- a/.agent-context/agent-handoffs.json
+++ b/.agent-context/agent-handoffs.json
@@ -1,18 +1,19 @@
 {
   "project": "adversarial-workflow",
   "description": "Multi-stage AI code review system - PyPI package",
-  "last_updated": "2026-03-18",
+  "last_updated": "2026-03-19",
   "agents": {
     "planner": {
-      "status": "idle",
-      "current_task": null,
-      "brief_note": "ADV-0062 complete (PR #54 merged). Also shipped: launcher --agent upgrade, FD3 autonomous bot polling.",
-      "details_link": null
+      "status": "completed",
+      "current_task": "ADV-0035, ADV-0057",
+      "brief_note": "COMPLETE: Backlog review, promoted ADV-0035 + ADV-0057 to todo, created handoffs",
+      "details_link": null,
+      "handoff_file": ".agent-context/ADV-0035-HANDOFF-feature-developer.md"
     },
     "feature-developer-v3": {
       "status": "idle",
       "current_task": null,
-      "brief_note": "ADV-0062 delivered and merged (PR #54). 1 thread, 1 round, 2 commits. Clean run.",
+      "brief_note": "ADV-0062 delivered and merged (PR #54). ADV-0035 and ADV-0057 ready for assignment.",
       "details_link": ".agent-context/retros/ADV-0062-retro.md"
     },
     "code-reviewer": {
@@ -36,12 +37,12 @@
     "ADV-0058: ci-check.sh parity - PR #50 merged (2026-03-16)"
   ],
   "pending_tasks": [
+    "ADV-0035: Evaluator runner test coverage (todo, ready)",
+    "ADV-0057: Review script robustness (todo, ready)",
     "ADV-0034: CLI library test coverage (backlog)",
-    "ADV-0035: Evaluator runner test coverage (backlog)",
     "ADV-0036: Library module test coverage (backlog)",
     "ADV-0055: Enhance health check (backlog, fold into ADV-0056)",
-    "ADV-0056: adversarial upgrade command (backlog)",
-    "ADV-0057: Review script robustness (backlog)"
+    "ADV-0056: adversarial upgrade command (backlog)"
   ],
   "blocked_items": [],
   "architecture_status": {
@@ -55,5 +56,5 @@
     "review_starters": ".agent-context/[TASK-ID]-REVIEW-STARTER.md",
     "reviews": ".agent-context/reviews/[TASK-ID]-review.md"
   },
-  "notes": "Quality gate alignment COMPLETE + ADV-0062 preflight auto-type. Process improvements shipped this session: (1) agents/launch uses --agent flag for status bar labels, (2) FD3 Phase 8 autonomous /wait-for-bots polling, (3) feedback memory on --agent flag for cross-project reuse."
+  "notes": "Backlog review completed 2026-03-19. Coverage at 64% overall (500 tests). ADV-0035 targets runner.py 72->85%. ADV-0057 fixes 4 review script edge cases. Recommended order: ADV-0035 first (higher impact), then ADV-0057."
 }

--- a/.agent-context/retros/ADV-0062-retro.md
+++ b/.agent-context/retros/ADV-0062-retro.md
@@ -1,0 +1,28 @@
+## ADV-0062 — Preflight Auto-Type from Task Spec (PR #54)
+
+**Date**: 2026-03-18
+**Agent**: feature-developer-v3
+**Scorecard**: 1 thread, 0 regressions, 1 fix round, 2 commits
+
+### What Worked
+
+1. **Handoff file was excellent** — exact insertion point, variable naming rationale (`TASK_FILE_FOR_TYPE` to avoid Gate 7 collision), and design decisions were all pre-decided. Implementation was copy-paste-level precise.
+2. **Testing the bash snippet in isolation** — instead of trying to run the full preflight script (which exits early without a PR), extracting the grep/sed/case logic into a standalone bash snippet made tests fast (0.09s) and reliable.
+3. **Single bot round** — CodeRabbit had only 1 minor finding (add returncode assertion), which was a legitimate improvement. Fixed in under 2 minutes.
+
+### What Was Surprising
+
+1. **Handoff's test strategy was slightly inaccurate** — it said "the script will fail on Gates 1-7 but prints MODE: before any gates run." In reality, the script exits at the PR auto-detection (line 153) before reaching MODE output (line 205). Testing the snippet in isolation was the correct workaround.
+2. **No BugBot review** — only CodeRabbit reviewed. BugBot (cursor[bot]) didn't post a review on this PR, possibly due to the small diff size.
+
+### What Should Change
+
+1. **Handoff test guidance should account for early exits** — when recommending "run the script and check output," the handoff should verify the execution flow reaches the output line. For preflight, the PR check exits before MODE is printed.
+
+### Permission Prompts Hit
+
+None.
+
+### Process Actions Taken
+
+- [ ] Update handoff template to verify execution flow when recommending "run script and check output" test strategies

--- a/.agent-context/reviews/ADV-0035-evaluator-review.md
+++ b/.agent-context/reviews/ADV-0035-evaluator-review.md
@@ -1,0 +1,32 @@
+# Evaluator Review — ADV-0035
+
+## Status: SKIPPED (auto-skip criteria met)
+
+**Date**: 2026-03-19
+**Task**: ADV-0035 — Evaluator Runner Test Coverage
+**PR**: #55
+
+## Skip Rationale
+
+All three auto-skip criteria are satisfied:
+
+1. **< 10 lines of source changed** — Zero lines of source changed.
+   `adversarial_workflow/evaluators/runner.py` was NOT modified.
+   Only `tests/test_evaluator_runner.py` was changed (test-only PR).
+
+2. **No new functions or classes** — No new production functions or classes.
+   New test functions/classes are test scaffolding, not production logic.
+
+3. **No external integrations** — No new subprocess calls, API calls, or
+   external dependencies introduced in source code.
+
+## Decision
+
+Per code-review-evaluator skill: "Skip without deliberation when ALL are true."
+All three conditions are true → evaluator skipped.
+
+## Coverage Achieved
+
+- `runner.py` coverage: **100%** (172/172 statements, up from 72%)
+- All 49 missing lines covered by 8 new test classes (74 total tests)
+- Full suite: 500+ tests, zero regressions

--- a/delegation/tasks/2-todo/ADV-0035-evaluator-runner-test-coverage.md
+++ b/delegation/tasks/2-todo/ADV-0035-evaluator-runner-test-coverage.md
@@ -1,8 +1,9 @@
 # ADV-0035: Evaluator Runner Test Coverage
 
-**Status**: Backlog
+**Status**: Todo
 **Priority**: High
 **Created**: 2026-02-07
+**Updated**: 2026-03-19
 **Type**: Testing
 **Estimated Effort**: 3-4 hours
 
@@ -10,17 +11,18 @@
 
 ## Problem Statement
 
-`evaluators/runner.py` has 64% test coverage. This module handles the core evaluation execution logic and should have comprehensive testing.
+`evaluators/runner.py` has 72% test coverage (172 stmts, 49 missing). This module handles the core evaluation execution logic and should have comprehensive testing.
 
-## Current State
+## Current State (as of 2026-03-19)
 
 ```
-adversarial_workflow/evaluators/runner.py   164     59    64%
+adversarial_workflow/evaluators/runner.py   172     49    72%
 
-Missing lines: 76-80, 84, 96-108, 185-186, 211-218, 231-262,
-               298-301, 306-307, 320-325, 330, 335-340
+Missing lines: 83-86, 90, 102-114, 193-194, 219-226, 250-258,
+               268-269, 312-315, 320-321, 334-339, 344, 349-354
 ```
 
+**Existing tests**: 30 tests in `tests/test_evaluator_runner.py` (4 classes: TestRunEvaluator, TestValidateEvaluationOutput, TestOutputFilenameExtension, TestAiderCommandFlags)
 **Target**: Increase runner.py coverage to 85%+
 
 ## Scope
@@ -47,10 +49,10 @@ Missing lines: 76-80, 84, 96-108, 185-186, 211-218, 231-262,
 - [ ] `_report_verdict()` has tests for:
   - [ ] All verdict types (APPROVED, NEEDS_REVISION, etc.)
 - [ ] Error paths covered:
-  - [ ] Lines 76-80: Aider not found
-  - [ ] Lines 96-108: Subprocess errors
-  - [ ] Lines 231-262: Output validation failures
-  - [ ] Lines 320-340: Timeout/cleanup
+  - [ ] Lines 83-86, 90: Aider not found
+  - [ ] Lines 102-114: Subprocess errors
+  - [ ] Lines 250-258, 268-269: Output validation failures
+  - [ ] Lines 334-354: Timeout/cleanup
 - [ ] Overall runner.py coverage reaches 85%+
 
 ## Implementation Notes
@@ -106,11 +108,11 @@ def mock_which(mocker):
 
 | Lines | Description | Priority |
 |-------|-------------|----------|
-| 76-80 | Aider not found error | High |
-| 96-108 | Subprocess error handling | High |
-| 231-262 | Output validation | Medium |
-| 320-340 | Timeout/cleanup | Medium |
-| 185-186, 211-218 | Edge cases | Low |
+| 83-86, 90 | Aider not found error | High |
+| 102-114 | Subprocess error handling | High |
+| 250-258, 268-269 | Output validation | Medium |
+| 334-354 | Timeout/cleanup | Medium |
+| 193-194, 219-226 | Edge cases | Low |
 
 ## Related
 

--- a/delegation/tasks/2-todo/ADV-0057-review-script-robustness.md
+++ b/delegation/tasks/2-todo/ADV-0057-review-script-robustness.md
@@ -1,10 +1,11 @@
 # ADV-0057: Review Script Robustness Improvements
 
-**Status**: Backlog
+**Status**: Todo
 **Priority**: Medium
 **Type**: Enhancement
 **Estimated Effort**: 1-2 hours
 **Created**: 2026-03-15
+**Updated**: 2026-03-19
 **Origin**: ADV-0054 code-reviewer-fast evaluator findings
 
 ## Summary

--- a/delegation/tasks/3-in-progress/ADV-0035-evaluator-runner-test-coverage.md
+++ b/delegation/tasks/3-in-progress/ADV-0035-evaluator-runner-test-coverage.md
@@ -1,6 +1,6 @@
 # ADV-0035: Evaluator Runner Test Coverage
 
-**Status**: Todo
+**Status**: In Progress
 **Priority**: High
 **Created**: 2026-02-07
 **Updated**: 2026-03-19

--- a/delegation/tasks/4-in-review/ADV-0035-evaluator-runner-test-coverage.md
+++ b/delegation/tasks/4-in-review/ADV-0035-evaluator-runner-test-coverage.md
@@ -1,0 +1,136 @@
+# ADV-0035: Evaluator Runner Test Coverage
+
+**Status**: In Review
+**Priority**: High
+**Created**: 2026-02-07
+**Updated**: 2026-03-19
+**Type**: Testing
+**Estimated Effort**: 3-4 hours
+
+---
+
+## Problem Statement
+
+`evaluators/runner.py` has 72% test coverage (172 stmts, 49 missing). This module handles the core evaluation execution logic and should have comprehensive testing.
+
+## Current State (as of 2026-03-19)
+
+```
+adversarial_workflow/evaluators/runner.py   172     49    72%
+
+Missing lines: 83-86, 90, 102-114, 193-194, 219-226, 250-258,
+               268-269, 312-315, 320-321, 334-339, 344, 349-354
+```
+
+**Existing tests**: 30 tests in `tests/test_evaluator_runner.py` (4 classes: TestRunEvaluator, TestValidateEvaluationOutput, TestOutputFilenameExtension, TestAiderCommandFlags)
+**Target**: Increase runner.py coverage to 85%+
+
+## Scope
+
+- `run_evaluator()` function - main entry point
+- `_check_file_size()` - output validation
+- `_report_verdict()` - verdict reporting
+- Aider subprocess handling
+- Error handling paths
+- Timeout handling
+
+## Acceptance Criteria
+
+- [ ] `run_evaluator()` has tests for:
+  - [ ] Successful evaluation
+  - [ ] Evaluator not found
+  - [ ] API key missing
+  - [ ] Aider failure (non-zero exit)
+  - [ ] Timeout handling
+- [ ] `_check_file_size()` has tests for:
+  - [ ] Valid output file
+  - [ ] Empty output file
+  - [ ] Missing output file
+- [ ] `_report_verdict()` has tests for:
+  - [ ] All verdict types (APPROVED, NEEDS_REVISION, etc.)
+- [ ] Error paths covered:
+  - [ ] Lines 83-86, 90: Aider not found
+  - [ ] Lines 102-114: Subprocess errors
+  - [ ] Lines 250-258, 268-269: Output validation failures
+  - [ ] Lines 334-354: Timeout/cleanup
+- [ ] Overall runner.py coverage reaches 85%+
+
+## Implementation Notes
+
+### Test Structure
+
+```python
+# tests/test_evaluator_runner.py (extend existing)
+
+class TestRunEvaluator:
+    def test_aider_not_found(self, ...):
+        """Test error when aider is not installed."""
+        ...
+
+    def test_api_key_missing(self, ...):
+        """Test error when API key env var is missing."""
+        ...
+
+    def test_aider_timeout(self, ...):
+        """Test timeout handling."""
+        ...
+
+class TestCheckFileSize:
+    def test_empty_output(self, ...):
+        ...
+
+    def test_missing_output(self, ...):
+        ...
+
+class TestReportVerdict:
+    @pytest.mark.parametrize("verdict", ["APPROVED", "NEEDS_REVISION", "REJECTED"])
+    def test_verdict_types(self, verdict, ...):
+        ...
+```
+
+### Mocking Strategy
+
+```python
+@pytest.fixture
+def mock_aider(mocker):
+    """Mock aider subprocess."""
+    mock_run = mocker.patch('subprocess.run')
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    return mock_run
+
+@pytest.fixture
+def mock_which(mocker):
+    """Mock shutil.which for aider detection."""
+    return mocker.patch('shutil.which', return_value='/usr/bin/aider')
+```
+
+### Priority Lines to Cover
+
+| Lines | Description | Priority |
+|-------|-------------|----------|
+| 83-86, 90 | Aider not found error | High |
+| 102-114 | Subprocess error handling | High |
+| 250-258, 268-269 | Output validation | Medium |
+| 334-354 | Timeout/cleanup | Medium |
+| 193-194, 219-226 | Edge cases | Low |
+
+## Related
+
+- ADV-0033: CLI Core Commands Test Coverage
+- Existing tests: `tests/test_evaluator_runner.py`
+
+---
+
+**Notes**: Most of the uncovered lines are error handling paths. Focus on testing failure scenarios.
+
+## Review
+
+**PR**: #55
+**Branch**: `feature/ADV-0035-runner-test-coverage` → `main`
+
+### Artifacts
+- Review starter: `.agent-context/ADV-0035-REVIEW-STARTER.md`
+- Evaluator review: `.agent-context/reviews/ADV-0035-evaluator-review.md`
+
+### Files Changed
+- `tests/test_evaluator_runner.py` (modified)

--- a/delegation/tasks/5-done/ADV-0062-preflight-auto-type-from-task-spec.md
+++ b/delegation/tasks/5-done/ADV-0062-preflight-auto-type-from-task-spec.md
@@ -1,6 +1,6 @@
 # ADV-0062: Preflight Auto-Detection from Task Spec Type Field
 
-**Status**: In Progress
+**Status**: Done
 **Priority**: Low
 **Type**: Enhancement
 **Estimated Effort**: 30 minutes

--- a/tests/test_evaluator_runner.py
+++ b/tests/test_evaluator_runner.py
@@ -980,18 +980,19 @@ class TestRunCustomEvaluatorErrors:
         captured = capsys.readouterr()
         assert "Error" in captured.out
 
-    def test_prompt_file_cleaned_up_after_timeout(self, tmp_path):
-        """finally block removes temp prompt file even on TimeoutExpired."""
+    def test_timeout_exception_does_not_propagate(self, tmp_path):
+        """TimeoutExpired is caught by the except block; the finally block runs and returns 1."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test content", encoding="utf-8")
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir()
 
         with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("aider", 30)):
-            # Just verify the call completes without raising — the finally block runs
-            _run_custom_evaluator(
+            result = _run_custom_evaluator(
                 self._make_config(), str(test_file), {"log_directory": str(logs_dir)}, 30, "gpt-4o"
             )
+
+        assert result == 1
 
     def test_successful_evaluation_calls_report_verdict(self, tmp_path, capsys):
         """On valid output, calls _report_verdict and returns its result (line 219)."""

--- a/tests/test_evaluator_runner.py
+++ b/tests/test_evaluator_runner.py
@@ -1,6 +1,7 @@
 """Tests for the generic evaluator runner."""
 
 import shutil
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,9 +9,16 @@ import pytest
 from adversarial_workflow.evaluators.config import EvaluatorConfig, ModelRequirement
 from adversarial_workflow.evaluators.runner import (
     _check_file_size,
+    _confirm_continue,
     _execute_script,
     _normalize_output_suffix,
+    _print_platform_error,
+    _print_rate_limit_error,
+    _print_timeout_error,
     _report_verdict,
+    _run_builtin_evaluator,
+    _run_custom_evaluator,
+    _warn_large_file,
     run_evaluator,
 )
 
@@ -632,3 +640,547 @@ class TestAiderCommandFlags:
             call_args = mock_run.call_args
             cmd = call_args[0][0]
             assert "--no-browser" in cmd, "aider command should include --no-browser flag"
+
+
+# ---------------------------------------------------------------------------
+# New tests for uncovered error paths (ADV-0035)
+# ---------------------------------------------------------------------------
+
+
+class TestRunEvaluatorLargeFile:
+    """Test large file handling paths in run_evaluator (lines 83-86)."""
+
+    def _setup_env(self, tmp_path, monkeypatch, config):
+        """Create the minimal filesystem+env for run_evaluator to reach the file-size check."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test", encoding="utf-8")
+
+        config_dir = tmp_path / ".adversarial"
+        config_dir.mkdir()
+        (config_dir / "config.yml").write_text(
+            "log_directory: .adversarial/logs/", encoding="utf-8"
+        )
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv(config.api_key_env, "test-key")
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/aider")
+        return test_file
+
+    def test_large_file_user_declines_returns_zero(
+        self, sample_config, tmp_path, monkeypatch, capsys
+    ):
+        """Large file (>700 lines) + user declining cancels evaluation and returns 0."""
+        test_file = self._setup_env(tmp_path, monkeypatch, sample_config)
+
+        with (
+            patch(
+                "adversarial_workflow.evaluators.runner._check_file_size",
+                return_value=(800, 25000),
+            ),
+            patch(
+                "adversarial_workflow.evaluators.runner._confirm_continue",
+                return_value=False,
+            ),
+        ):
+            result = run_evaluator(sample_config, str(test_file))
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Evaluation cancelled" in captured.out
+
+    def test_large_file_warning_displayed(self, sample_config, tmp_path, monkeypatch, capsys):
+        """Large file triggers the large-file warning before prompting."""
+        test_file = self._setup_env(tmp_path, monkeypatch, sample_config)
+
+        with (
+            patch(
+                "adversarial_workflow.evaluators.runner._check_file_size",
+                return_value=(800, 25000),
+            ),
+            patch(
+                "adversarial_workflow.evaluators.runner._confirm_continue",
+                return_value=False,
+            ),
+        ):
+            run_evaluator(sample_config, str(test_file))
+
+        captured = capsys.readouterr()
+        assert "Large file detected" in captured.out
+
+    def test_large_file_user_accepts_continues(self, sample_config, tmp_path, monkeypatch):
+        """Large file + user accepting continues to evaluation (doesn't return 0 early)."""
+        test_file = self._setup_env(tmp_path, monkeypatch, sample_config)
+
+        mock_subprocess = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
+        with (
+            patch(
+                "adversarial_workflow.evaluators.runner._check_file_size",
+                return_value=(800, 25000),
+            ),
+            patch(
+                "adversarial_workflow.evaluators.runner._confirm_continue",
+                return_value=True,
+            ),
+            patch("subprocess.run", mock_subprocess),
+        ):
+            run_evaluator(sample_config, str(test_file))
+
+        # Aider was invoked — proves evaluation was not cancelled
+        assert mock_subprocess.called
+
+
+class TestWarnLargeFile:
+    """Direct tests for _warn_large_file helper (lines 312-315)."""
+
+    def test_prints_large_file_detected(self, capsys):
+        """Prints 'Large file detected' heading."""
+        _warn_large_file(600, 25000)
+        captured = capsys.readouterr()
+        assert "Large file detected" in captured.out
+
+    def test_prints_line_count(self, capsys):
+        """Prints formatted line count."""
+        _warn_large_file(600, 25000)
+        captured = capsys.readouterr()
+        assert "600" in captured.out
+
+    def test_prints_token_estimate(self, capsys):
+        """Prints formatted estimated token count."""
+        _warn_large_file(600, 25000)
+        captured = capsys.readouterr()
+        assert "25,000" in captured.out
+
+
+class TestConfirmContinue:
+    """Direct tests for _confirm_continue helper (lines 320-321)."""
+
+    def test_y_returns_true(self):
+        """User typing 'y' means continue."""
+        with patch("builtins.input", return_value="y"):
+            assert _confirm_continue() is True
+
+    def test_yes_returns_true(self):
+        """User typing 'yes' means continue."""
+        with patch("builtins.input", return_value="yes"):
+            assert _confirm_continue() is True
+
+    def test_uppercase_y_returns_true(self):
+        """User typing 'Y' (uppercase) is treated as yes after lower()."""
+        with patch("builtins.input", return_value="Y"):
+            assert _confirm_continue() is True
+
+    def test_n_returns_false(self):
+        """User typing 'n' means cancel."""
+        with patch("builtins.input", return_value="n"):
+            assert _confirm_continue() is False
+
+    def test_empty_returns_false(self):
+        """Empty input (pressing Enter) defaults to No."""
+        with patch("builtins.input", return_value=""):
+            assert _confirm_continue() is False
+
+    def test_arbitrary_text_returns_false(self):
+        """Any other input defaults to No."""
+        with patch("builtins.input", return_value="maybe"):
+            assert _confirm_continue() is False
+
+
+class TestRunBuiltinEvaluatorPath:
+    """Test the builtin evaluator path in run_evaluator and _run_builtin_evaluator."""
+
+    def test_builtin_path_taken_when_source_is_builtin(self, tmp_path, monkeypatch, capsys):
+        """run_evaluator routes to _run_builtin_evaluator when source='builtin' (line 90)."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test", encoding="utf-8")
+
+        config_dir = tmp_path / ".adversarial"
+        config_dir.mkdir()
+        (config_dir / "config.yml").write_text(
+            "log_directory: .adversarial/logs/", encoding="utf-8"
+        )
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/aider")
+
+        config = EvaluatorConfig(
+            name="evaluate",
+            description="Plan evaluation",
+            model="gpt-4o",
+            api_key_env="OPENAI_API_KEY",
+            prompt="",
+            output_suffix="PLAN-EVALUATION",
+            source="builtin",
+        )
+
+        # Script doesn't exist in tmp_path → script-not-found error from _run_builtin_evaluator
+        result = run_evaluator(config, str(test_file))
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Script not found" in captured.out
+
+    def test_script_not_found_for_unknown_name(self, tmp_path, capsys):
+        """Error when evaluator name is not in the script_map (lines 109-112)."""
+        config = EvaluatorConfig(
+            name="no-such-builtin",
+            description="Test",
+            model="gpt-4o",
+            api_key_env="OPENAI_API_KEY",
+            prompt="",
+            output_suffix="TEST",
+            source="builtin",
+        )
+
+        result = _run_builtin_evaluator(
+            config, "/some/file.md", {"log_directory": str(tmp_path)}, 30
+        )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Script not found" in captured.out
+
+    def test_script_not_found_for_known_name_missing_file(self, tmp_path, monkeypatch, capsys):
+        """Error when known name but script file doesn't exist on disk (lines 109-112)."""
+        monkeypatch.chdir(tmp_path)  # .adversarial/scripts/ doesn't exist here
+
+        config = EvaluatorConfig(
+            name="evaluate",
+            description="Plan evaluation",
+            model="gpt-4o",
+            api_key_env="OPENAI_API_KEY",
+            prompt="",
+            output_suffix="PLAN-EVALUATION",
+            source="builtin",
+        )
+
+        result = _run_builtin_evaluator(
+            config, "/some/file.md", {"log_directory": str(tmp_path)}, 30
+        )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Script not found" in captured.out
+
+    def test_execute_script_called_when_script_exists(self, tmp_path, monkeypatch):
+        """_execute_script is called when the script file is found (line 114)."""
+        # Create the expected builtin script path
+        scripts_dir = tmp_path / ".adversarial" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        fake_script = scripts_dir / "evaluate_plan.sh"
+        fake_script.write_text("#!/bin/bash\necho done", encoding="utf-8")
+
+        # Pre-create the log file that validate_evaluation_output expects
+        logs_dir = tmp_path / ".adversarial" / "logs"
+        logs_dir.mkdir()
+        log_file = logs_dir / "test-PLAN-EVALUATION.md"
+        log_file.write_text(
+            "## Verdict: APPROVED\n\n" + "Evaluation details. " * 30, encoding="utf-8"
+        )
+
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test", encoding="utf-8")
+
+        monkeypatch.chdir(tmp_path)
+
+        config = EvaluatorConfig(
+            name="evaluate",
+            description="Plan evaluation",
+            model="gpt-4o",
+            api_key_env="OPENAI_API_KEY",
+            prompt="",
+            output_suffix="PLAN-EVALUATION",
+            source="builtin",
+        )
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+            result = _run_builtin_evaluator(
+                config, str(test_file), {"log_directory": str(logs_dir)}, 30
+            )
+
+        assert result == 0
+
+
+class TestRunCustomEvaluatorErrors:
+    """Test error paths in _run_custom_evaluator (lines 193-194, 219-226)."""
+
+    def _make_config(self):
+        return EvaluatorConfig(
+            name="test-eval",
+            description="Test",
+            model="gpt-4o",
+            api_key_env="OPENAI_API_KEY",
+            prompt="Test prompt",
+            output_suffix="TEST",
+            source="custom",
+        )
+
+    def test_rate_limit_error_in_stdout(self, tmp_path, capsys):
+        """RateLimitError in subprocess stdout triggers rate-limit handling (lines 193-194)."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test content", encoding="utf-8")
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+
+        mock_result = MagicMock(returncode=0, stdout="RateLimitError: exceeded quota", stderr="")
+        with patch("subprocess.run", return_value=mock_result):
+            result = _run_custom_evaluator(
+                self._make_config(), str(test_file), {"log_directory": str(logs_dir)}, 30, "gpt-4o"
+            )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "rate limit" in captured.out.lower()
+
+    def test_rate_limit_error_in_stderr(self, tmp_path, capsys):
+        """'tokens per min' in stderr also triggers rate-limit handling."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test content", encoding="utf-8")
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+
+        mock_result = MagicMock(returncode=0, stdout="", stderr="tokens per min limit reached")
+        with patch("subprocess.run", return_value=mock_result):
+            result = _run_custom_evaluator(
+                self._make_config(), str(test_file), {"log_directory": str(logs_dir)}, 30, "gpt-4o"
+            )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "rate limit" in captured.out.lower()
+
+    def test_timeout_expired_returns_one(self, tmp_path, capsys):
+        """TimeoutExpired from subprocess returns 1 with timeout message (lines 219-223)."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test content", encoding="utf-8")
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("aider", 30)):
+            result = _run_custom_evaluator(
+                self._make_config(), str(test_file), {"log_directory": str(logs_dir)}, 30, "gpt-4o"
+            )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "timed out" in captured.out.lower()
+
+    def test_file_not_found_error_returns_one(self, tmp_path, capsys):
+        """FileNotFoundError from subprocess returns 1 with platform error (lines 224-226)."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test content", encoding="utf-8")
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            result = _run_custom_evaluator(
+                self._make_config(), str(test_file), {"log_directory": str(logs_dir)}, 30, "gpt-4o"
+            )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Error" in captured.out
+
+    def test_prompt_file_cleaned_up_after_timeout(self, tmp_path):
+        """finally block removes temp prompt file even on TimeoutExpired."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test content", encoding="utf-8")
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("aider", 30)):
+            # Just verify the call completes without raising — the finally block runs
+            _run_custom_evaluator(
+                self._make_config(), str(test_file), {"log_directory": str(logs_dir)}, 30, "gpt-4o"
+            )
+
+    def test_successful_evaluation_calls_report_verdict(self, tmp_path, capsys):
+        """On valid output, calls _report_verdict and returns its result (line 219)."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test content", encoding="utf-8")
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+
+        # Produce enough stdout so header + stdout >= 500 bytes, with a clear verdict
+        large_stdout = "Verdict: APPROVED\n\n" + "Evaluation details. " * 30
+
+        mock_result = MagicMock(returncode=0, stdout=large_stdout, stderr="")
+        with patch("subprocess.run", return_value=mock_result):
+            result = _run_custom_evaluator(
+                self._make_config(), str(test_file), {"log_directory": str(logs_dir)}, 30, "gpt-4o"
+            )
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "APPROVED" in captured.out
+
+
+class TestExecuteScriptErrors:
+    """Test error paths in _execute_script (lines 250-258, 268-269)."""
+
+    def _make_builtin_config(self):
+        return EvaluatorConfig(
+            name="evaluate",
+            description="Plan evaluation",
+            model="gpt-4o",
+            api_key_env="OPENAI_API_KEY",
+            prompt="",
+            output_suffix="PLAN-EVALUATION",
+            source="builtin",
+        )
+
+    def test_timeout_expired_returns_one(self, tmp_path, capsys):
+        """TimeoutExpired during script execution returns 1 (lines 253-255)."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test", encoding="utf-8")
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("script.sh", 30)):
+            result = _execute_script(
+                "/fake/script.sh",
+                str(test_file),
+                self._make_builtin_config(),
+                {"log_directory": str(tmp_path)},
+                30,
+            )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "timed out" in captured.out.lower()
+
+    def test_file_not_found_returns_one(self, tmp_path, capsys):
+        """FileNotFoundError during script execution returns 1 (lines 256-258)."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test", encoding="utf-8")
+
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            result = _execute_script(
+                "/fake/script.sh",
+                str(test_file),
+                self._make_builtin_config(),
+                {"log_directory": str(tmp_path)},
+                30,
+            )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Error" in captured.out
+
+    def test_missing_output_file_fails_validation(self, tmp_path, capsys):
+        """Missing log file after script run triggers validation failure (lines 268-269)."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test", encoding="utf-8")
+
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        # Deliberately do NOT create the expected log file
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+            result = _execute_script(
+                "/fake/script.sh",
+                str(test_file),
+                self._make_builtin_config(),
+                {"log_directory": str(logs_dir)},
+                30,
+            )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Evaluation failed" in captured.out
+
+    def test_rate_limit_in_script_output_returns_one(self, tmp_path, capsys):
+        """RateLimitError in script stdout triggers rate-limit handling (lines 250-251)."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test", encoding="utf-8")
+
+        mock_result = MagicMock(returncode=0, stdout="RateLimitError: quota exceeded", stderr="")
+        with patch("subprocess.run", return_value=mock_result):
+            result = _execute_script(
+                "/fake/script.sh",
+                str(test_file),
+                self._make_builtin_config(),
+                {"log_directory": str(tmp_path)},
+                30,
+            )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "rate limit" in captured.out.lower()
+
+
+class TestHelperFunctions:
+    """Direct tests for standalone helper functions (lines 334-354)."""
+
+    def test_print_rate_limit_error_outputs_message(self, capsys):
+        """_print_rate_limit_error prints rate limit message (lines 334-339)."""
+        _print_rate_limit_error("test-file.md")
+        captured = capsys.readouterr()
+        assert "rate limit" in captured.out.lower()
+
+    def test_print_rate_limit_error_includes_solutions(self, capsys):
+        """_print_rate_limit_error prints the SOLUTIONS block."""
+        _print_rate_limit_error("test-file.md")
+        captured = capsys.readouterr()
+        assert "SOLUTIONS" in captured.out
+
+    def test_print_timeout_error_shows_duration(self, capsys):
+        """_print_timeout_error prints timeout message with the configured duration (line 344)."""
+        _print_timeout_error(300)
+        captured = capsys.readouterr()
+        assert "timed out" in captured.out.lower()
+        assert "300" in captured.out
+
+    def test_print_platform_error_non_windows(self, capsys):
+        """_print_platform_error on Linux prints 'adversarial init' hint (lines 349-354)."""
+        with patch("platform.system", return_value="Linux"):
+            _print_platform_error()
+        captured = capsys.readouterr()
+        assert "Error" in captured.out
+        # Non-Windows path mentions init hint
+        assert "adversarial init" in captured.out or "Script not found" in captured.out
+
+    def test_print_platform_error_windows(self, capsys):
+        """_print_platform_error on Windows mentions WSL (lines 349-354)."""
+        with patch("platform.system", return_value="Windows"):
+            _print_platform_error()
+        captured = capsys.readouterr()
+        assert "Windows" in captured.out
+        assert "WSL" in captured.out
+
+
+class TestReportVerdictAllTypes:
+    """Test _report_verdict with every verdict string in each set."""
+
+    @pytest.mark.parametrize("verdict", ["APPROVED", "PROCEED", "COMPLIANT", "PASS"])
+    def test_pass_verdicts_return_zero(self, verdict, sample_config, tmp_path, capsys):
+        """All PASS-set verdicts return 0."""
+        log_file = tmp_path / "out.md"
+        log_file.write_text("content", encoding="utf-8")
+        result = _report_verdict(verdict, log_file, sample_config)
+        assert result == 0
+        captured = capsys.readouterr()
+        assert verdict in captured.out
+
+    @pytest.mark.parametrize(
+        "verdict",
+        ["NEEDS_REVISION", "REVISION_SUGGESTED", "MOSTLY_COMPLIANT", "CONCERNS"],
+    )
+    def test_revise_verdicts_return_one(self, verdict, sample_config, tmp_path, capsys):
+        """All REVISE-set verdicts return 1."""
+        log_file = tmp_path / "out.md"
+        log_file.write_text("content", encoding="utf-8")
+        result = _report_verdict(verdict, log_file, sample_config)
+        assert result == 1
+        captured = capsys.readouterr()
+        assert verdict in captured.out
+
+    @pytest.mark.parametrize(
+        "verdict",
+        ["REJECTED", "RETHINK", "RESTRUCTURE_NEEDED", "NON_COMPLIANT", "FAIL"],
+    )
+    def test_reject_verdicts_return_one(self, verdict, sample_config, tmp_path, capsys):
+        """All REJECT-set verdicts return 1."""
+        log_file = tmp_path / "out.md"
+        log_file.write_text("content", encoding="utf-8")
+        result = _report_verdict(verdict, log_file, sample_config)
+        assert result == 1
+        captured = capsys.readouterr()
+        assert verdict in captured.out

--- a/tests/test_evaluator_runner.py
+++ b/tests/test_evaluator_runner.py
@@ -723,10 +723,12 @@ class TestRunEvaluatorLargeFile:
             ),
             patch("subprocess.run", mock_subprocess),
         ):
-            run_evaluator(sample_config, str(test_file))
+            result = run_evaluator(sample_config, str(test_file))
 
         # Aider was invoked — proves evaluation was not cancelled
         assert mock_subprocess.called
+        # Validation fails on empty stdout, so result is 1 (not the early-cancel 0)
+        assert result == 1
 
 
 class TestWarnLargeFile:
@@ -980,20 +982,6 @@ class TestRunCustomEvaluatorErrors:
         captured = capsys.readouterr()
         assert "Error" in captured.out
 
-    def test_timeout_exception_does_not_propagate(self, tmp_path):
-        """TimeoutExpired is caught by the except block; the finally block runs and returns 1."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test content", encoding="utf-8")
-        logs_dir = tmp_path / "logs"
-        logs_dir.mkdir()
-
-        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("aider", 30)):
-            result = _run_custom_evaluator(
-                self._make_config(), str(test_file), {"log_directory": str(logs_dir)}, 30, "gpt-4o"
-            )
-
-        assert result == 1
-
     def test_successful_evaluation_calls_report_verdict(self, tmp_path, capsys):
         """On valid output, calls _report_verdict and returns its result (line 219)."""
         test_file = tmp_path / "test.md"
@@ -1135,8 +1123,8 @@ class TestHelperFunctions:
             _print_platform_error()
         captured = capsys.readouterr()
         assert "Error" in captured.out
-        # Non-Windows path mentions init hint
-        assert "adversarial init" in captured.out or "Script not found" in captured.out
+        assert "Script not found" in captured.out
+        assert "adversarial init" in captured.out
 
     def test_print_platform_error_windows(self, capsys):
         """_print_platform_error on Windows mentions WSL (lines 349-354)."""

--- a/tests/test_evaluator_runner.py
+++ b/tests/test_evaluator_runner.py
@@ -790,7 +790,7 @@ class TestConfirmContinue:
 class TestRunBuiltinEvaluatorPath:
     """Test the builtin evaluator path in run_evaluator and _run_builtin_evaluator."""
 
-    def test_builtin_path_taken_when_source_is_builtin(self, tmp_path, monkeypatch, capsys):
+    def test_builtin_path_taken_when_source_is_builtin(self, tmp_path, monkeypatch):
         """run_evaluator routes to _run_builtin_evaluator when source='builtin' (line 90)."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test", encoding="utf-8")
@@ -815,11 +815,14 @@ class TestRunBuiltinEvaluatorPath:
             source="builtin",
         )
 
-        # Script doesn't exist in tmp_path → script-not-found error from _run_builtin_evaluator
-        result = run_evaluator(config, str(test_file))
-        assert result == 1
-        captured = capsys.readouterr()
-        assert "Script not found" in captured.out
+        # Mock _run_builtin_evaluator directly to verify routing (not just output text)
+        with patch(
+            "adversarial_workflow.evaluators.runner._run_builtin_evaluator",
+            return_value=0,
+        ) as mock_builtin:
+            result = run_evaluator(config, str(test_file))
+            assert result == 0
+        mock_builtin.assert_called_once()
 
     def test_script_not_found_for_unknown_name(self, tmp_path, capsys):
         """Error when evaluator name is not in the script_map (lines 109-112)."""
@@ -894,12 +897,16 @@ class TestRunBuiltinEvaluatorPath:
             source="builtin",
         )
 
-        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+        with patch(
+            "adversarial_workflow.evaluators.runner._execute_script",
+            return_value=0,
+        ) as mock_execute:
             result = _run_builtin_evaluator(
                 config, str(test_file), {"log_directory": str(logs_dir)}, 30
             )
 
         assert result == 0
+        mock_execute.assert_called_once()
 
 
 class TestRunCustomEvaluatorErrors:

--- a/tests/test_evaluator_runner.py
+++ b/tests/test_evaluator_runner.py
@@ -906,7 +906,14 @@ class TestRunBuiltinEvaluatorPath:
             )
 
         assert result == 0
-        mock_execute.assert_called_once()
+        # Runner resolves script relative to cwd (monkeypatched to tmp_path)
+        mock_execute.assert_called_once_with(
+            ".adversarial/scripts/evaluate_plan.sh",
+            str(test_file),
+            config,
+            {"log_directory": str(logs_dir)},
+            30,
+        )
 
 
 class TestRunCustomEvaluatorErrors:


### PR DESCRIPTION
## Summary
- Added 44 new tests across 8 new test classes covering all 49 previously-uncovered lines in `evaluators/runner.py`
- Coverage jumps from 72% (123/172 stmts) to **100%** (172/172 stmts)
- All error paths now have a safety net: aider not found, rate limits, timeouts, FileNotFoundError, large-file prompt, output validation failures
- New code follows DK002 (`encoding="utf-8"` on all `write_text()` calls); pre-existing violations untouched (tracked in ADV-0061)

## What was covered
| Lines | Path | Test class |
|-------|------|------------|
| 83-86 | Large file cancel prompt in `run_evaluator` | `TestRunEvaluatorLargeFile` |
| 90, 102-114 | Builtin evaluator routing + script-not-found | `TestRunBuiltinEvaluatorPath` |
| 193-194, 219-226 | Rate limit / timeout / FileNotFoundError in `_run_custom_evaluator` | `TestRunCustomEvaluatorErrors` |
| 250-258, 268-269 | Timeout / FileNotFoundError / invalid output in `_execute_script` | `TestExecuteScriptErrors` |
| 312-321 | `_warn_large_file` + `_confirm_continue` helpers | `TestWarnLargeFile`, `TestConfirmContinue` |
| 334-354 | `_print_rate_limit_error` / `_print_timeout_error` / `_print_platform_error` | `TestHelperFunctions` |

## Test Plan
- [x] `runner.py` coverage: **100%** (target was 85%+)
- [x] Full suite: **544 tests pass**, zero regressions
- [x] `ruff check` passes on changed file
- [x] Pattern lint: my new code is DK002-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR is test- and metadata-only; it expands coverage around subprocess/error handling without changing production behavior.
> 
> **Overview**
> Raises `adversarial_workflow/evaluators/runner.py` coverage from ~72% to **100%** by appending ~550 lines of new tests in `tests/test_evaluator_runner.py`.
> 
> The new tests exercise previously-uncovered branches: large-file warnings and confirmation prompt, builtin-vs-custom routing, script-not-found handling, rate-limit/timeout/FileNotFoundError paths for subprocess execution, output validation failures, and all verdict categories. Internal task/agent tracking docs are also updated/added (handoffs, review starter, task status transitions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6f4323733417e12564f728514f619403edc99a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->