### PR TITLE
fix: Harden review script and CLI against edge-case inputs (ADV-0057)

### DIFF
--- a/.adversarial/scripts/review_implementation.sh
+++ b/.adversarial/scripts/review_implementation.sh
@@ -20,17 +20,21 @@ TASK_DIR=$(grep 'task_directory:' .adversarial/config.yml | awk '{print $2}')
 LOG_DIR=$(grep 'log_directory:' .adversarial/config.yml | awk '{print $2}')
 ARTIFACTS_DIR=$(grep 'artifacts_directory:' .adversarial/config.yml | awk '{print $2}')
 
+# Provide sensible defaults when config values are missing (Fix 1: ADV-0057)
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-.adversarial/artifacts/}
+LOG_DIR=${LOG_DIR:-.adversarial/logs/}
+
 TASK_FILE="$1"
 
-if [ -z "$TASK_FILE" ]; then
-  echo "Usage: ./.adversarial/scripts/review_implementation.sh <task_file_path>"
-  echo ""
-  echo "Example: ./.adversarial/scripts/review_implementation.sh ${TASK_DIR}TASK-2025-001.md"
-  exit 1
-fi
-
-if [ ! -f "$TASK_FILE" ]; then
-  echo "Error: Task file not found: $TASK_FILE"
+# Validate task file: handle both empty and missing cases (Fix 4: ADV-0057)
+if [ -z "$TASK_FILE" ] || [ ! -f "$TASK_FILE" ]; then
+  if [ -z "$TASK_FILE" ]; then
+    echo "Usage: ./.adversarial/scripts/review_implementation.sh <task_file_path>"
+    echo ""
+    echo "Example: ./.adversarial/scripts/review_implementation.sh ${TASK_DIR}TASK-2025-001.md"
+  else
+    echo "Error: Task file not found: $TASK_FILE"
+  fi
   exit 1
 fi
 
@@ -53,6 +57,12 @@ mkdir -p "$LOG_DIR"
 DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
 DEFAULT_BRANCH=${DEFAULT_BRANCH#origin/}
 DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+
+# Validate the resolved branch ref actually exists (Fix 2: ADV-0057)
+if ! git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  echo "Error: Cannot find base branch '$DEFAULT_BRANCH'. Set origin/HEAD or pass branch explicitly."
+  exit 1
+fi
 
 # Capture current implementation state
 echo "=== Capturing implementation artifacts ==="

--- a/.agent-context/agent-handoffs.json
+++ b/.agent-context/agent-handoffs.json
@@ -1,20 +1,20 @@
 {
   "project": "adversarial-workflow",
   "description": "Multi-stage AI code review system - PyPI package",
-  "last_updated": "2026-03-19",
+  "last_updated": "2026-03-20",
   "agents": {
     "planner": {
-      "status": "completed",
-      "current_task": "ADV-0035, ADV-0057",
-      "brief_note": "COMPLETE: Backlog review, promoted ADV-0035 + ADV-0057 to todo, created handoffs",
+      "status": "idle",
+      "current_task": null,
+      "brief_note": "ADV-0035 complete (PR #55 merged, 100% coverage). ADV-0057 ready for assignment.",
       "details_link": null,
-      "handoff_file": ".agent-context/ADV-0035-HANDOFF-feature-developer.md"
+      "handoff_file": ".agent-context/ADV-0057-HANDOFF-feature-developer.md"
     },
     "feature-developer-v3": {
       "status": "idle",
       "current_task": null,
-      "brief_note": "ADV-0062 delivered and merged (PR #54). ADV-0035 and ADV-0057 ready for assignment.",
-      "details_link": ".agent-context/retros/ADV-0062-retro.md"
+      "brief_note": "ADV-0035 delivered and merged (PR #55). runner.py 72%→100%. 8 threads, 3 fix rounds, 7 commits.",
+      "details_link": ".agent-context/retros/ADV-0035-retro.md"
     },
     "code-reviewer": {
       "status": "idle",
@@ -30,14 +30,13 @@
     }
   },
   "recent_completions": [
+    "ADV-0035: Evaluator runner test coverage - PR #55 merged, 100% coverage (2026-03-20)",
     "ADV-0062: Preflight auto-type from task spec - PR #54 merged (2026-03-18)",
     "ADV-0061: Fix DK002 violations, promote pattern lint to blocking - PR #53 merged (2026-03-18)",
     "ADV-0060: Preflight task-type modes - PR #52 merged (2026-03-17)",
-    "ADV-0059: GH Actions paths alignment - PR #51 merged (2026-03-17)",
-    "ADV-0058: ci-check.sh parity - PR #50 merged (2026-03-16)"
+    "ADV-0059: GH Actions paths alignment - PR #51 merged (2026-03-17)"
   ],
   "pending_tasks": [
-    "ADV-0035: Evaluator runner test coverage (todo, ready)",
     "ADV-0057: Review script robustness (todo, ready)",
     "ADV-0034: CLI library test coverage (backlog)",
     "ADV-0036: Library module test coverage (backlog)",
@@ -56,5 +55,5 @@
     "review_starters": ".agent-context/[TASK-ID]-REVIEW-STARTER.md",
     "reviews": ".agent-context/reviews/[TASK-ID]-review.md"
   },
-  "notes": "Backlog review completed 2026-03-19. Coverage at 64% overall (500 tests). ADV-0035 targets runner.py 72->85%. ADV-0057 fixes 4 review script edge cases. Recommended order: ADV-0035 first (higher impact), then ADV-0057."
+  "notes": "ADV-0035 exceeded target: runner.py at 100% (was 72%, target was 85%). Retro noted ADV-0063 (consecutive-quote heuristic) as blocker for autonomous triage. ADV-0057 is next in queue (1-2h, 4 fixes)."
 }

--- a/adversarial_workflow/cli.py
+++ b/adversarial_workflow/cli.py
@@ -2125,7 +2125,21 @@ def review(task_file: str) -> int:
         if default_branch.returncode == 0
         else "main"
     )
-    branch_diff = subprocess.run(["git", "diff", "--quiet", f"{base}...HEAD"], capture_output=True)
+    branch_diff = subprocess.run(
+        ["git", "diff", "--quiet", f"{base}...HEAD"], capture_output=True, text=True
+    )
+
+    # Fix 3 (ADV-0057): git diff returns 1 for "has changes", but values >= 128
+    # indicate a git error (e.g. invalid ref). Catch and report before proceeding.
+    if branch_diff.returncode >= 128:
+        print(f"{RED}❌ ERROR: Cannot compare against base branch '{base}'{RESET}")
+        stderr_msg = branch_diff.stderr.strip() if branch_diff.stderr else ""
+        if stderr_msg:
+            print(f"   Git error: {stderr_msg}")
+        print("   Fix: Ensure origin/HEAD is set, or that 'main' branch exists.")
+        print("   Run: git remote set-head origin --auto")
+        return 1
+
     staged_diff = subprocess.run(["git", "diff", "--cached", "--quiet"], capture_output=True)
     unstaged_diff = subprocess.run(["git", "diff", "--quiet"], capture_output=True)
 

--- a/adversarial_workflow/templates/review_implementation.sh.template
+++ b/adversarial_workflow/templates/review_implementation.sh.template
@@ -75,17 +75,21 @@ TASK_DIR=$(grep 'task_directory:' .adversarial/config.yml | awk '{print $2}')
 LOG_DIR=$(grep 'log_directory:' .adversarial/config.yml | awk '{print $2}')
 ARTIFACTS_DIR=$(grep 'artifacts_directory:' .adversarial/config.yml | awk '{print $2}')
 
+# Provide sensible defaults when config values are missing (Fix 1: ADV-0057)
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-.adversarial/artifacts/}
+LOG_DIR=${LOG_DIR:-.adversarial/logs/}
+
 TASK_FILE="$1"
 
-if [ -z "$TASK_FILE" ]; then
-  echo "Usage: ./.adversarial/scripts/review_implementation.sh <task_file_path>"
-  echo ""
-  echo "Example: ./.adversarial/scripts/review_implementation.sh ${TASK_DIR}TASK-2025-001.md"
-  exit 1
-fi
-
-if [ ! -f "$TASK_FILE" ]; then
-  echo "Error: Task file not found: $TASK_FILE"
+# Validate task file: handle both empty and missing cases (Fix 4: ADV-0057)
+if [ -z "$TASK_FILE" ] || [ ! -f "$TASK_FILE" ]; then
+  if [ -z "$TASK_FILE" ]; then
+    echo "Usage: ./.adversarial/scripts/review_implementation.sh <task_file_path>"
+    echo ""
+    echo "Example: ./.adversarial/scripts/review_implementation.sh ${TASK_DIR}TASK-2025-001.md"
+  else
+    echo "Error: Task file not found: $TASK_FILE"
+  fi
   exit 1
 fi
 
@@ -108,6 +112,12 @@ mkdir -p "$LOG_DIR"
 DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
 DEFAULT_BRANCH=${DEFAULT_BRANCH#origin/}
 DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+
+# Validate the resolved branch ref actually exists (Fix 2: ADV-0057)
+if ! git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  echo "Error: Cannot find base branch '$DEFAULT_BRANCH'. Set origin/HEAD or pass branch explicitly."
+  exit 1
+fi
 
 # Capture current implementation state
 echo "=== Capturing implementation artifacts ==="

--- a/delegation/tasks/3-in-progress/ADV-0057-review-script-robustness.md
+++ b/delegation/tasks/3-in-progress/ADV-0057-review-script-robustness.md
@@ -1,0 +1,92 @@
+# ADV-0057: Review Script Robustness Improvements
+
+**Status**: In Progress
+**Priority**: Medium
+**Type**: Enhancement
+**Estimated Effort**: 1-2 hours
+**Created**: 2026-03-15
+**Updated**: 2026-03-19
+**Origin**: ADV-0054 code-reviewer-fast evaluator findings
+
+## Summary
+
+The adversarial code-review evaluator (Gemini Flash) identified 4 robustness
+gaps in `review_implementation.sh` and its CLI wrapper during the ADV-0054
+review. All are pre-existing edge cases (not regressions), but worth hardening.
+
+## Issues to Address
+
+### 1. Empty `ARTIFACTS_DIR` / `LOG_DIR` from config parsing
+
+**Risk**: Medium
+**Files**: `review_implementation.sh`, template
+
+If `artifacts_directory` or `log_directory` is missing from `.adversarial/config.yml`,
+the variables are empty strings. `mkdir -p ""` creates nothing useful, and subsequent
+file writes go to unexpected paths.
+
+**Fix**: Add validation after config parsing:
+```bash
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-.adversarial/artifacts/}
+LOG_DIR=${LOG_DIR:-.adversarial/logs/}
+```
+
+### 2. Non-existent default branch fallback
+
+**Risk**: Low
+**Files**: `review_implementation.sh`, template, `cli.py`
+
+If `origin/HEAD` is not set AND the repo uses `master` (not `main`), the fallback
+to `main` causes `git diff main...HEAD` to fail.
+
+**Fix**: After setting `DEFAULT_BRANCH`, verify the ref exists:
+```bash
+if ! git rev-parse --verify "$DEFAULT_BRANCH" >/dev/null 2>&1; then
+  echo "Error: Cannot find base branch '$DEFAULT_BRANCH'. Set origin/HEAD or pass branch explicitly."
+  exit 1
+fi
+```
+
+### 3. CLI pre-check error handling
+
+**Risk**: Low
+**Files**: `adversarial_workflow/cli.py` (`review()`)
+
+When `git diff base...HEAD` fails due to invalid refs, the non-zero exit code
+correctly prevents the "no changes" abort, but the script then crashes with an
+unhelpful git error. The CLI could catch this and provide a better message.
+
+**Fix**: Check `branch_diff.returncode` for values > 1 (git error vs changes detected)
+and report the issue before invoking the script.
+
+### 4. Invalid `task_file` edge cases in bash script
+
+**Risk**: Low
+**Files**: `review_implementation.sh`, template
+
+The script validates file existence but doesn't handle empty strings well
+(`basename "" .md` produces `.`). The CLI now requires `task_file`, so this
+is only reachable if the script is invoked directly.
+
+**Fix**: Add early validation:
+```bash
+if [ -z "$TASK_FILE" ] || [ ! -f "$TASK_FILE" ]; then
+  echo "Error: Task file not found or not specified: $TASK_FILE"
+  exit 1
+fi
+```
+
+## Acceptance Criteria
+
+- [ ] Config variables have sensible defaults when missing from config.yml
+- [ ] Default branch fallback validates the ref exists before using it
+- [ ] CLI provides clear error when git state is invalid for review
+- [ ] Script handles empty/invalid task_file gracefully
+- [ ] Template and committed script remain in sync
+- [ ] All existing tests pass
+
+## Notes
+
+- These are all pre-existing issues, not regressions from ADV-0054
+- Evaluator review: `.agent-context/reviews/ADV-0054-code-reviewer-fast.md`
+- Consider adding integration tests for the review script if feasible

--- a/tests/test_cli_core.py
+++ b/tests/test_cli_core.py
@@ -1421,3 +1421,43 @@ class TestInitTemplateErrors:
         assert result == 1
         captured = capsys.readouterr()
         assert "ERROR" in captured.out or "failed" in captured.out.lower()
+
+
+class TestReviewFunction:
+    """Test the review() function error handling (ADV-0057)."""
+
+    def test_review_git_error_returns_clear_message(self, capsys):
+        """review() should report a clear error when git diff fails with invalid refs."""
+        from adversarial_workflow.cli import review
+
+        # Simulate: git symbolic-ref fails (returncode=1), then git diff fails
+        # with returncode 128 (git error, e.g. invalid ref)
+        symbolic_ref_result = Mock(returncode=1, stdout="", stderr="")
+        branch_diff_result = Mock(
+            returncode=128, stdout="", stderr="fatal: Not a valid object name 'main'"
+        )
+
+        with patch("adversarial_workflow.cli.subprocess.run") as mock_run:
+            mock_run.side_effect = [symbolic_ref_result, branch_diff_result]
+            result = review("some_task.md")
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Cannot compare against base branch" in captured.out
+        assert "main" in captured.out
+
+    def test_review_git_error_high_returncode(self, capsys):
+        """review() should catch any git returncode >= 128 as an error."""
+        from adversarial_workflow.cli import review
+
+        symbolic_ref_result = Mock(returncode=1, stdout="", stderr="")
+        # returncode 129 is also a git error (e.g. bad flag)
+        branch_diff_result = Mock(returncode=129, stdout="", stderr="fatal: unrecognized argument")
+
+        with patch("adversarial_workflow.cli.subprocess.run") as mock_run:
+            mock_run.side_effect = [symbolic_ref_result, branch_diff_result]
+            result = review("some_task.md")
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Cannot compare against base branch" in captured.out


### PR DESCRIPTION
## Summary

- **Fix 1**: Config defaults — `ARTIFACTS_DIR`/`LOG_DIR` get sensible defaults (`.adversarial/artifacts/`, `.adversarial/logs/`) when missing from `config.yml`
- **Fix 2**: Branch validation — verify resolved default branch ref exists before `git diff`, with clear error message
- **Fix 3**: CLI error handling — detect `git diff` errors (returncode ≥ 128) in `review()` and report actionable message instead of cascading failure
- **Fix 4**: Task file validation — handle empty `TASK_FILE` strings gracefully in bash script (prevents `basename ""` producing `.`)

## Test plan

- [x] 545 tests pass (2 new tests for Fix 3)
- [x] Ruff format + lint clean
- [x] Pattern lint (DK rules) clean
- [x] Template and committed script remain in sync
- [x] `ci-check.sh` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrow changes to workflow scripting and `adversarial review` preflight checks, plus added unit tests; main risk is inadvertently blocking reviews in unusual git branch setups.
> 
> **Overview**
> Improves Phase 3 review robustness by adding default fallbacks for missing `artifacts_directory`/`log_directory`, stricter `task_file` validation, and a base-branch existence check before generating diffs in `review_implementation.sh` (and its template).
> 
> Updates `adversarial_workflow.cli.review()` to detect `git diff` *errors* (`returncode >= 128`) and emit an actionable message instead of continuing, with new unit tests covering these error paths.
> 
> Includes minor project metadata/task-tracking updates (agent handoff JSON refresh and an `ADV-0057` in-progress task doc).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0382a131f6762ee2b1c3f83013b0543f36e5a370. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->