### PR TITLE
fix: Extract verdicts from bold markdown formats (ADV-0072)

### DIFF
--- a/.adversarial/inputs/ADV-0072-code-review-input.md
+++ b/.adversarial/inputs/ADV-0072-code-review-input.md
@@ -1,0 +1,61 @@
+# Code Review Input: ADV-0072
+
+## Task
+Fix verdict extraction for bold markdown formats in `validate_evaluation_output()`.
+
+## Spec Summary
+- Extract verdicts from Gemini Flash outputs that use bold markdown (`**FAIL**`, `- **FAIL**: ...`)
+- Prevent false positives from incidental bold words in prose (`**FAIL**ure modes discussed`)
+- All existing verdict formats must still work (no regression)
+- Tests cover each new pattern variant
+
+## Acceptance Criteria
+1. Gemini Flash `code-reviewer-fast` verdicts extracted correctly
+2. Gemini Flash `spec-compliance` verdicts extracted correctly
+3. o1 `code-reviewer` verdicts still extracted correctly (no regression)
+4. All existing verdict patterns still work (bare, `Verdict:`, `**Verdict**:`)
+5. Tests cover each new pattern variant
+6. Property test: verdict in any recognized bold format is extracted
+
+## Changed Files
+
+### adversarial_workflow/utils/validation.py
+- Added 3 new regex patterns for bold-wrapped verdicts
+- Anchored ALL patterns at line boundaries (`^\s*` prefix + `\s*$` suffix)
+- Prevents false positives from mid-line matches and substring matches
+
+### tests/test_utils_validation.py
+- Added `TestVerdictFormatExtraction` class with parametrized tests
+- 91 format × verdict combinations (7 formats × 13 verdicts)
+- 13 case-insensitive bold tests
+- 5 false-positive rejection tests (prose substrings, bold substrings, key-value substrings)
+- 3 positive regression tests (list item, standalone, bold key+value)
+
+## Diff
+
+```diff
+--- a/adversarial_workflow/utils/validation.py
++++ b/adversarial_workflow/utils/validation.py
+@@ -46,9 +46,12 @@
+     verdict_patterns = [
+-        rf"Verdict:\s*({all_verdicts})",
+-        rf"\*\*Verdict\*\*:\s*({all_verdicts})",
+-        rf"^({all_verdicts})\s*$",
++        rf"^\s*Verdict:\s*({all_verdicts})\s*$",
++        rf"^\s*\*\*Verdict\*\*:\s*({all_verdicts})\s*$",
++        rf"^\s*\*\*Verdict\*\*:\s*\*\*({all_verdicts})\*\*\s*$",
++        rf"^\s*[-*]\s+\*\*({all_verdicts})\*\*(?::|\s*$)",
++        rf"^\s*\*\*({all_verdicts})\*\*\s*$",
++        rf"^({all_verdicts})\s*$",
+     ]
+```
+
+## Test Results
+- 120 tests pass (all validation tests)
+- 643 total tests pass (full suite, excluding pre-existing version flag issue)
+- validation.py has 100% coverage
+
+## Bot Review Status
+- CodeRabbit: APPROVED (3 rounds, all threads resolved)
+- BugBot: No findings
+- CI: Green

--- a/.kit/context/ADV-0072-REVIEW-STARTER.md
+++ b/.kit/context/ADV-0072-REVIEW-STARTER.md
@@ -1,0 +1,42 @@
+# Review Starter: ADV-0072
+
+**Task**: ADV-0072 - Fix Verdict Extraction for Bold Markdown Formats
+**Task File**: `.kit/tasks/4-in-review/ADV-0072-fix-verdict-extraction-bold-markdown.md`
+**Branch**: feature/ADV-0072-fix-verdict-extraction -> main
+**PR**: https://github.com/movito/adversarial-workflow/pull/68
+
+## Implementation Summary
+- Added 3 new regex patterns to `validate_evaluation_output()` for bold-wrapped verdicts (`**FAIL**`, `- **FAIL**: ...`, `**Verdict**: **FAIL**`)
+- Anchored ALL 6 verdict patterns at line boundaries (`^\s*` prefix + `\s*$` suffix) to prevent false positives from mid-line matches and substring matches (e.g., `**FAIL**ure`, `**FAIL**ed`)
+- Added comprehensive parametrized test suite (120 tests) covering all 13 verdicts × 7 formats, plus 6 false-positive rejection tests
+
+## Files Changed
+- `adversarial_workflow/utils/validation.py` (modified) — 3 new patterns, all 6 patterns anchored
+- `tests/test_utils_validation.py` (modified) — new `TestVerdictFormatExtraction` class with 120 tests
+
+## Test Results
+- 120 validation tests passing
+- 643 total tests passing (pre-existing `test_version_flag` excluded)
+- `validation.py` at 100% coverage
+
+## Automated Review Summary
+- **BugBot**: Clean — no findings
+- **CodeRabbit**: APPROVED after 3 rounds
+  - Round 1: Original bold patterns too loose (fixed)
+  - Round 2: `**Verdict**: **FAIL**` pattern also needed anchoring + ruff format (fixed)
+  - Round 3: Keyed patterns needed `^\s*` line-start anchor (fixed)
+  - All 4 threads resolved
+- **Code-review evaluator (o1)**: CONCERNS
+  - Finding 1: Bullet-item trailing text — false positive, already tested by `test_bold_verdict_with_trailing_text` and parametrized `list_item_bold_dash`
+  - Finding 2: Unicode whitespace — accepted low risk, LLM outputs use standard UTF-8
+
+## Areas for Review Focus
+- Pattern ordering: higher-specificity patterns (keyed `Verdict:`) match first, lower-specificity (bare line) last — intentional to prefer explicit verdicts
+- The `(?::|\s*$)` alternation in the list-item pattern allows both `- **FAIL**:` (with trailing text) and `- **FAIL**` (standalone) — verify this meets expected behavior
+- The `re.IGNORECASE` flag means patterns match `**fail**` as well as `**FAIL**`
+
+## Related ADRs
+- None (bug fix, no architectural changes)
+
+---
+**Ready for human review**

--- a/.kit/context/reviews/ADV-0072-evaluator-review.md
+++ b/.kit/context/reviews/ADV-0072-evaluator-review.md
@@ -1,0 +1,25 @@
+# ADV-0072 Evaluator Review
+
+**Evaluator**: code-reviewer (o1)
+**Verdict**: CONCERNS
+**Date**: 2026-04-15
+
+## Findings
+
+### 1. Bullet-item line may not match with trailing text (CORRECTNESS)
+**Disposition**: False positive — already tested
+- The regex `(?::|\s*$)` matches either `:` OR end-of-line, not "colon then end"
+- `test_bold_verdict_with_trailing_text` covers `- **FAIL**: Correctness bugs found.`
+- Parametrized `list_item_bold_dash` covers `- **{verdict}**: Some description here`
+- Both tests pass — the pattern correctly handles trailing text after colon
+
+### 2. Unicode/whitespace edge cases (ROBUSTNESS)
+**Disposition**: Acknowledged, accepted risk
+- LLM API outputs use standard UTF-8 text
+- Zero-width spaces or unusual line breaks are not observed in practice
+- Risk is latent and extremely low
+- No action taken
+
+## Conclusion
+Both concerns are either already covered by tests or accepted low risk.
+No code changes required.

--- a/.kit/tasks/3-in-progress/ADV-0072-fix-verdict-extraction-bold-markdown.md
+++ b/.kit/tasks/3-in-progress/ADV-0072-fix-verdict-extraction-bold-markdown.md
@@ -1,6 +1,6 @@
 # ADV-0072: Fix Verdict Extraction for Bold Markdown Formats
 
-**Status**: Backlog
+**Status**: In Progress
 **Priority**: Medium
 **Type**: Bug fix
 **Estimated Effort**: 1-2 hours

--- a/.kit/tasks/4-in-review/ADV-0072-fix-verdict-extraction-bold-markdown.md
+++ b/.kit/tasks/4-in-review/ADV-0072-fix-verdict-extraction-bold-markdown.md
@@ -1,6 +1,6 @@
 # ADV-0072: Fix Verdict Extraction for Bold Markdown Formats
 
-**Status**: In Progress
+**Status**: In Review
 **Priority**: Medium
 **Type**: Bug fix
 **Estimated Effort**: 1-2 hours
@@ -91,3 +91,16 @@ Each verdict name × each format variant:
 - Affects all Gemini-based evaluators (~$0.004/run), which are the most commonly used
 - The evaluation content is correct — only the verdict extraction/display is broken
 - No impact on human-readable output (the log file is fine), only on CLI status reporting
+
+## Review
+
+**PR**: #68
+**Branch**: feature/ADV-0072-fix-verdict-extraction -> main
+
+### Artifacts
+- Review starter: `.kit/context/ADV-0072-REVIEW-STARTER.md`
+- Evaluator review: `.kit/context/reviews/ADV-0072-evaluator-review.md`
+
+### Files Changed
+- `adversarial_workflow/utils/validation.py` (modified)
+- `tests/test_utils_validation.py` (modified)

--- a/adversarial_workflow/utils/validation.py
+++ b/adversarial_workflow/utils/validation.py
@@ -49,8 +49,8 @@ def validate_evaluation_output(
         rf"Verdict:\s*({all_verdicts})",
         rf"\*\*Verdict\*\*:\s*({all_verdicts})",
         rf"\*\*Verdict\*\*:\s*\*\*({all_verdicts})\*\*",  # **Verdict**: **FAIL**
-        rf"[-*]\s*\*\*({all_verdicts})\*\*",  # - **FAIL**: ... (list item)
-        rf"^\*\*({all_verdicts})\*\*",  # **FAIL** at line start
+        rf"^\s*[-*]\s+\*\*({all_verdicts})\*\*(?::|\s*$)",  # list item verdict line
+        rf"^\s*\*\*({all_verdicts})\*\*\s*$",  # bold verdict as full line
         rf"^({all_verdicts})\s*$",  # FAIL (bare line)
     ]
 

--- a/adversarial_workflow/utils/validation.py
+++ b/adversarial_workflow/utils/validation.py
@@ -48,7 +48,10 @@ def validate_evaluation_output(
     verdict_patterns = [
         rf"Verdict:\s*({all_verdicts})",
         rf"\*\*Verdict\*\*:\s*({all_verdicts})",
-        rf"^({all_verdicts})\s*$",
+        rf"\*\*Verdict\*\*:\s*\*\*({all_verdicts})\*\*",  # **Verdict**: **FAIL**
+        rf"[-*]\s*\*\*({all_verdicts})\*\*",  # - **FAIL**: ... (list item)
+        rf"^\*\*({all_verdicts})\*\*",  # **FAIL** at line start
+        rf"^({all_verdicts})\s*$",  # FAIL (bare line)
     ]
 
     for pattern in verdict_patterns:

--- a/adversarial_workflow/utils/validation.py
+++ b/adversarial_workflow/utils/validation.py
@@ -46,9 +46,9 @@ def validate_evaluation_output(
         "|PASS|CONCERNS|FAIL"  # code-reviewer
     )
     verdict_patterns = [
-        rf"Verdict:\s*({all_verdicts})\s*$",
-        rf"\*\*Verdict\*\*:\s*({all_verdicts})\s*$",
-        rf"\*\*Verdict\*\*:\s*\*\*({all_verdicts})\*\*\s*$",  # **Verdict**: **FAIL**
+        rf"^\s*Verdict:\s*({all_verdicts})\s*$",
+        rf"^\s*\*\*Verdict\*\*:\s*({all_verdicts})\s*$",
+        rf"^\s*\*\*Verdict\*\*:\s*\*\*({all_verdicts})\*\*\s*$",  # **Verdict**: **FAIL**
         rf"^\s*[-*]\s+\*\*({all_verdicts})\*\*(?::|\s*$)",  # list item verdict line
         rf"^\s*\*\*({all_verdicts})\*\*\s*$",  # bold verdict as full line
         rf"^({all_verdicts})\s*$",  # FAIL (bare line)

--- a/adversarial_workflow/utils/validation.py
+++ b/adversarial_workflow/utils/validation.py
@@ -46,9 +46,9 @@ def validate_evaluation_output(
         "|PASS|CONCERNS|FAIL"  # code-reviewer
     )
     verdict_patterns = [
-        rf"Verdict:\s*({all_verdicts})",
-        rf"\*\*Verdict\*\*:\s*({all_verdicts})",
-        rf"\*\*Verdict\*\*:\s*\*\*({all_verdicts})\*\*",  # **Verdict**: **FAIL**
+        rf"Verdict:\s*({all_verdicts})\s*$",
+        rf"\*\*Verdict\*\*:\s*({all_verdicts})\s*$",
+        rf"\*\*Verdict\*\*:\s*\*\*({all_verdicts})\*\*\s*$",  # **Verdict**: **FAIL**
         rf"^\s*[-*]\s+\*\*({all_verdicts})\*\*(?::|\s*$)",  # list item verdict line
         rf"^\s*\*\*({all_verdicts})\*\*\s*$",  # bold verdict as full line
         rf"^({all_verdicts})\s*$",  # FAIL (bare line)

--- a/tests/test_utils_validation.py
+++ b/tests/test_utils_validation.py
@@ -1,6 +1,40 @@
 """Tests for validation utilities."""
 
+import pytest
+
 from adversarial_workflow.utils.validation import validate_evaluation_output
+
+# Padding to exceed the 500-byte minimum content threshold
+_PAD = "Evaluation details. " * 30  # ~600 bytes
+
+
+# All recognized verdicts for parametrized tests
+_ALL_VERDICTS = [
+    "APPROVED",
+    "NEEDS_REVISION",
+    "REJECTED",
+    "PROCEED",
+    "RETHINK",
+    "REVISION_SUGGESTED",
+    "RESTRUCTURE_NEEDED",
+    "COMPLIANT",
+    "MOSTLY_COMPLIANT",
+    "NON_COMPLIANT",
+    "PASS",
+    "CONCERNS",
+    "FAIL",
+]
+
+# Format templates: each produces a line containing the verdict
+_VERDICT_FORMATS = {
+    "bare_line": "{verdict}",
+    "verdict_prefix": "Verdict: {verdict}",
+    "bold_key": "**Verdict**: {verdict}",
+    "bold_key_bold_value": "**Verdict**: **{verdict}**",
+    "bold_value_line_start": "**{verdict}**",
+    "list_item_bold_dash": "- **{verdict}**: Some description here",
+    "list_item_bold_star": "* **{verdict}**: Some description here",
+}
 
 
 class TestValidateEvaluationOutput:
@@ -130,3 +164,66 @@ Some evaluation content here
         assert is_valid is True
         assert verdict is None
         assert "verdict not detected" in message.lower()
+
+
+class TestVerdictFormatExtraction:
+    """Parametrized tests for all verdict format x verdict name combinations."""
+
+    @pytest.mark.parametrize("verdict", _ALL_VERDICTS)
+    @pytest.mark.parametrize(
+        "fmt_name,fmt_template",
+        list(_VERDICT_FORMATS.items()),
+        ids=list(_VERDICT_FORMATS.keys()),
+    )
+    def test_verdict_format_combinations(self, tmp_path, verdict, fmt_name, fmt_template):
+        """Every recognized verdict is extracted from every supported format."""
+        verdict_line = fmt_template.format(verdict=verdict)
+        content = f"# Evaluation\n\n{_PAD}\n\n{verdict_line}\n"
+
+        log_file = tmp_path / f"{fmt_name}_{verdict}.md"
+        log_file.write_text(content)
+
+        is_valid, extracted, _msg = validate_evaluation_output(str(log_file))
+        assert is_valid is True, f"Expected valid for {fmt_name} / {verdict}"
+        assert extracted == verdict, f"Expected {verdict} from format '{fmt_name}', got {extracted}"
+
+    @pytest.mark.parametrize("verdict", _ALL_VERDICTS)
+    def test_bold_value_case_insensitive(self, tmp_path, verdict):
+        """Bold-wrapped verdicts are extracted case-insensitively."""
+        content = f"# Eval\n\n{_PAD}\n\n**{verdict.lower()}**\n"
+        log_file = tmp_path / f"bold_lower_{verdict}.md"
+        log_file.write_text(content)
+
+        is_valid, extracted, _msg = validate_evaluation_output(str(log_file))
+        assert is_valid is True
+        assert extracted == verdict
+
+    def test_bold_verdict_with_trailing_text(self, tmp_path):
+        """Bold verdict in list item with trailing description is extracted."""
+        content = f"# Eval\n\n{_PAD}\n\n- **FAIL**: Correctness bugs found.\n"
+        log_file = tmp_path / "list_trailing.md"
+        log_file.write_text(content)
+
+        is_valid, verdict, _msg = validate_evaluation_output(str(log_file))
+        assert is_valid is True
+        assert verdict == "FAIL"
+
+    def test_bold_non_compliant_line_start(self, tmp_path):
+        """Gemini Flash spec-compliance format: **NON_COMPLIANT** at line start."""
+        content = f"# Spec Compliance\n\n{_PAD}\n\n**NON_COMPLIANT**\n"
+        log_file = tmp_path / "gemini_spec.md"
+        log_file.write_text(content)
+
+        is_valid, verdict, _msg = validate_evaluation_output(str(log_file))
+        assert is_valid is True
+        assert verdict == "NON_COMPLIANT"
+
+    def test_bold_key_bold_value(self, tmp_path):
+        """Bold key AND bold value: **Verdict**: **FAIL**."""
+        content = f"# Review\n\n{_PAD}\n\n**Verdict**: **FAIL**\n"
+        log_file = tmp_path / "bold_both.md"
+        log_file.write_text(content)
+
+        is_valid, verdict, _msg = validate_evaluation_output(str(log_file))
+        assert is_valid is True
+        assert verdict == "FAIL"

--- a/tests/test_utils_validation.py
+++ b/tests/test_utils_validation.py
@@ -218,6 +218,50 @@ class TestVerdictFormatExtraction:
         assert is_valid is True
         assert verdict == "NON_COMPLIANT"
 
+    def test_bold_verdict_word_in_prose_not_false_positive(self, tmp_path):
+        """**FAIL**ure in prose should not match — real verdict later should win."""
+        content = (
+            f"# Review\n\n{_PAD}\n\n"
+            "**FAIL**ure modes discussed in the architecture.\n\n"
+            "Verdict: APPROVED\n"
+        )
+        log_file = tmp_path / "false_positive_prose.md"
+        log_file.write_text(content)
+
+        is_valid, verdict, _msg = validate_evaluation_output(str(log_file))
+        assert is_valid is True
+        assert verdict == "APPROVED", f"Should extract APPROVED from Verdict: line, got {verdict}"
+
+    def test_list_item_bold_only_verdict_still_matches(self, tmp_path):
+        """A list-item bold verdict as the only verdict still matches."""
+        content = f"# Review\n\n{_PAD}\n\n- **FAIL**: Correctness issues found\n"
+        log_file = tmp_path / "list_only_verdict.md"
+        log_file.write_text(content)
+
+        is_valid, verdict, _msg = validate_evaluation_output(str(log_file))
+        assert is_valid is True
+        assert verdict == "FAIL"
+
+    def test_standalone_bold_verdict_line_still_matches(self, tmp_path):
+        """A standalone **APPROVED** on its own line still matches."""
+        content = f"# Review\n\n{_PAD}\n\n**APPROVED**\n"
+        log_file = tmp_path / "standalone_bold.md"
+        log_file.write_text(content)
+
+        is_valid, verdict, _msg = validate_evaluation_output(str(log_file))
+        assert is_valid is True
+        assert verdict == "APPROVED"
+
+    def test_bold_verdict_substring_not_matched(self, tmp_path):
+        """**FAIL**ed should not match the bold-line pattern."""
+        content = f"# Review\n\n{_PAD}\n\n**FAIL**ed to meet standards.\n\nVerdict: APPROVED\n"
+        log_file = tmp_path / "bold_substring.md"
+        log_file.write_text(content)
+
+        is_valid, verdict, _msg = validate_evaluation_output(str(log_file))
+        assert is_valid is True
+        assert verdict == "APPROVED", f"Should extract APPROVED, not FAIL from substring, got {verdict}"
+
     def test_bold_key_bold_value(self, tmp_path):
         """Bold key AND bold value: **Verdict**: **FAIL**."""
         content = f"# Review\n\n{_PAD}\n\n**Verdict**: **FAIL**\n"

--- a/tests/test_utils_validation.py
+++ b/tests/test_utils_validation.py
@@ -260,7 +260,23 @@ class TestVerdictFormatExtraction:
 
         is_valid, verdict, _msg = validate_evaluation_output(str(log_file))
         assert is_valid is True
-        assert verdict == "APPROVED", f"Should extract APPROVED, not FAIL from substring, got {verdict}"
+        assert verdict == "APPROVED", (
+            f"Should extract APPROVED, not FAIL from substring, got {verdict}"
+        )
+
+    def test_bold_verdict_key_value_substring_not_matched(self, tmp_path):
+        """**Verdict**: **FAIL**ed should not false-positive on FAIL."""
+        content = (
+            f"# Review\n\n{_PAD}\n\n**Verdict**: **FAIL**ed due to context.\n\nVerdict: APPROVED\n"
+        )
+        log_file = tmp_path / "bold_kv_substring.md"
+        log_file.write_text(content)
+
+        is_valid, verdict, _msg = validate_evaluation_output(str(log_file))
+        assert is_valid is True
+        assert verdict == "APPROVED", (
+            f"Should extract APPROVED, not FAIL from bold key-value substring, got {verdict}"
+        )
 
     def test_bold_key_bold_value(self, tmp_path):
         """Bold key AND bold value: **Verdict**: **FAIL**."""


### PR DESCRIPTION
## Summary

- **Bug**: Gemini Flash evaluators wrap verdicts in markdown bold (`**FAIL**`, `**NON_COMPLIANT**`) but the verdict extraction regex only matched bare text, causing `verdict: None` for all Gemini-based evaluators
- **Fix**: Added 3 regex patterns to handle bold-wrapped verdict formats: `**Verdict**: **FAIL**`, `- **FAIL**: description`, and `**FAIL**` at line start
- **Tests**: 115 parametrized tests covering all 13 recognized verdicts × 7 format variants (was 8 tests)

## Files Changed

| File | Change |
|------|--------|
| `adversarial_workflow/utils/validation.py` | Added 3 regex patterns for bold markdown verdict formats |
| `tests/test_utils_validation.py` | Added parametrized test matrix (13 verdicts × 7 formats) + edge case tests |

## Test plan

- [x] All 115 validation tests pass locally
- [x] Full CI suite passes (639 tests, `validation.py` at 100% coverage)
- [x] No regression on existing verdict patterns (bare, `Verdict:`, `**Verdict**:`)
- [ ] CI passes on GitHub
- [ ] Bot reviews addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to regex-based verdict parsing and add extensive tests; main risk is minor behavior change if anchoring affects previously accepted non-line-based verdict strings.
> 
> **Overview**
> Updates `validate_evaluation_output()` verdict extraction to support Gemini-style bold markdown outputs (e.g., `**Verdict**: **FAIL**`, `- **FAIL**: ...`, `**FAIL**`) and **anchors all patterns to line boundaries** to avoid mid-line/substring matches.
> 
> Adds a large parametrized test matrix covering all recognized verdicts across multiple formats, plus targeted cases for case-insensitive bold matching and false-positive rejection (e.g., `**FAIL**ure`, `**FAIL**ed`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07c165b8c5b1ed8c6c6d0e7a1f0a7021e4af24a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->