### PR TITLE
fix: non-TTY auto-yes for >700-line large-file prompt

### DIFF
--- a/adversarial_workflow/evaluators/runner.py
+++ b/adversarial_workflow/evaluators/runner.py
@@ -252,17 +252,24 @@ def _confirm_continue() -> bool:
     movito/adversarial-workflow#69 for the opt-in gate rationale.
     """
     if not sys.stdin.isatty():
-        if os.environ.get("ADVERSARIAL_UNATTENDED") == "1":
+        unattended = os.environ.get("ADVERSARIAL_UNATTENDED")
+        if unattended == "1":
             print(
                 "Non-TTY context detected and ADVERSARIAL_UNATTENDED=1 set "
                 "— auto-confirming large input."
             )
             return True
-        print(
-            "Non-TTY context detected and ADVERSARIAL_UNATTENDED is unset "
-            "— auto-cancelling. Set ADVERSARIAL_UNATTENDED=1 to opt into "
-            "unattended approval of large inputs."
-        )
+        if unattended is None:
+            print(
+                "Non-TTY context detected and ADVERSARIAL_UNATTENDED is unset "
+                "— auto-cancelling. Set ADVERSARIAL_UNATTENDED=1 to opt into "
+                "unattended approval of large inputs."
+            )
+        else:
+            print(
+                "Non-TTY context detected and ADVERSARIAL_UNATTENDED is set to "
+                f"{unattended!r} (expected '1') — auto-cancelling."
+            )
         return False
     response = input("Continue anyway? [y/N]: ").strip().lower()
     return response in ["y", "yes"]

--- a/adversarial_workflow/evaluators/runner.py
+++ b/adversarial_workflow/evaluators/runner.py
@@ -10,6 +10,7 @@ Transport: Uses litellm.completion() for LLM calls (ADV-0065).
 from __future__ import annotations
 
 import os
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -232,7 +233,20 @@ def _warn_large_file(line_count: int, tokens: int) -> None:
 
 
 def _confirm_continue() -> bool:
-    """Ask user to confirm continuing with large file."""
+    """Ask user to confirm continuing with large file.
+
+    Non-TTY contexts (CI runs, agentic harnesses, piped invocations)
+    auto-confirm: prompting for input without a terminal raises
+    EOFError and aborts the evaluation, which is worse than running
+    a slightly-too-large evaluation. When stdin is not a TTY we print
+    a notice and proceed.
+
+    See: ID2-0043 / ID2-0046 retros (ixda-services-2.0) for the
+    non-TTY EOFError friction this guard fixes.
+    """
+    if not sys.stdin.isatty():
+        print("Non-TTY context detected — auto-confirming large input.")
+        return True
     response = input("Continue anyway? [y/N]: ").strip().lower()
     return response in ["y", "yes"]
 

--- a/adversarial_workflow/evaluators/runner.py
+++ b/adversarial_workflow/evaluators/runner.py
@@ -235,18 +235,35 @@ def _warn_large_file(line_count: int, tokens: int) -> None:
 def _confirm_continue() -> bool:
     """Ask user to confirm continuing with large file.
 
-    Non-TTY contexts (CI runs, agentic harnesses, piped invocations)
-    auto-confirm: prompting for input without a terminal raises
-    EOFError and aborts the evaluation, which is worse than running
-    a slightly-too-large evaluation. When stdin is not a TTY we print
-    a notice and proceed.
+    Behavior by context:
+
+    - **TTY (interactive)**: prompt as before; default is No.
+    - **Non-TTY with `ADVERSARIAL_UNATTENDED=1`**: auto-confirm with a
+      printed notice. This is the explicit opt-in for CI runs and
+      agentic harnesses that want to spend the tokens unattended.
+    - **Non-TTY without the env var**: auto-cancel (return False) with
+      a printed notice. Calling `input()` in this context would raise
+      EOFError and abort the run; cancelling is the safer default
+      because it avoids both the crash and silently-approved expensive
+      evaluations.
 
     See: ID2-0043 / ID2-0046 retros (ixda-services-2.0) for the
-    non-TTY EOFError friction this guard fixes.
+    original non-TTY EOFError friction; CodeRabbit re-review on PR
+    movito/adversarial-workflow#69 for the opt-in gate rationale.
     """
     if not sys.stdin.isatty():
-        print("Non-TTY context detected — auto-confirming large input.")
-        return True
+        if os.environ.get("ADVERSARIAL_UNATTENDED") == "1":
+            print(
+                "Non-TTY context detected and ADVERSARIAL_UNATTENDED=1 set "
+                "— auto-confirming large input."
+            )
+            return True
+        print(
+            "Non-TTY context detected and ADVERSARIAL_UNATTENDED is unset "
+            "— auto-cancelling. Set ADVERSARIAL_UNATTENDED=1 to opt into "
+            "unattended approval of large inputs."
+        )
+        return False
     response = input("Continue anyway? [y/N]: ").strip().lower()
     return response in ["y", "yes"]
 

--- a/tests/test_evaluator_runner.py
+++ b/tests/test_evaluator_runner.py
@@ -814,8 +814,9 @@ class TestConfirmContinue:
         ):
             assert _confirm_continue() is False
 
-    def test_non_tty_auto_confirms(self, capsys):
-        """Non-TTY context: auto-confirm without prompting."""
+    def test_non_tty_with_unattended_env_auto_confirms(self, capsys, monkeypatch):
+        """Non-TTY + ADVERSARIAL_UNATTENDED=1: auto-confirm with notice."""
+        monkeypatch.setenv("ADVERSARIAL_UNATTENDED", "1")
         with (
             patch("sys.stdin.isatty", return_value=False),
             # If we accidentally fall through to input(), this side_effect
@@ -827,7 +828,49 @@ class TestConfirmContinue:
         ):
             assert _confirm_continue() is True
         captured = capsys.readouterr()
-        assert "Non-TTY" in captured.out or "auto-confirming" in captured.out
+        assert "ADVERSARIAL_UNATTENDED=1" in captured.out
+        assert "auto-confirming" in captured.out
+
+    def test_non_tty_without_unattended_env_auto_cancels(self, capsys, monkeypatch):
+        """Non-TTY without env var: auto-cancel (fail-safe), don't prompt.
+
+        Default behavior change after CodeRabbit re-review on PR
+        movito/adversarial-workflow#69: bare isatty()==False used to
+        auto-confirm, which silently approves expensive runs in CI.
+        Now the default is cancel; opt in via ADVERSARIAL_UNATTENDED=1.
+        """
+        monkeypatch.delenv("ADVERSARIAL_UNATTENDED", raising=False)
+        with (
+            patch("sys.stdin.isatty", return_value=False),
+            patch(
+                "builtins.input",
+                side_effect=AssertionError("input() should not be called in non-TTY"),
+            ),
+        ):
+            assert _confirm_continue() is False
+        captured = capsys.readouterr()
+        assert "auto-cancelling" in captured.out
+        assert "ADVERSARIAL_UNATTENDED=1" in captured.out
+
+    def test_non_tty_with_unattended_other_value_auto_cancels(
+        self, capsys, monkeypatch
+    ):
+        """Non-TTY + ADVERSARIAL_UNATTENDED set to non-'1' value: still cancels.
+
+        Strict opt-in: only the literal string '1' enables auto-confirm.
+        Prevents accidental opt-in from typo'd values like 'true', 'yes', etc.
+        """
+        monkeypatch.setenv("ADVERSARIAL_UNATTENDED", "true")
+        with (
+            patch("sys.stdin.isatty", return_value=False),
+            patch(
+                "builtins.input",
+                side_effect=AssertionError("input() should not be called in non-TTY"),
+            ),
+        ):
+            assert _confirm_continue() is False
+        captured = capsys.readouterr()
+        assert "auto-cancelling" in captured.out
 
 
 class TestBuiltinEvaluatorPath:

--- a/tests/test_evaluator_runner.py
+++ b/tests/test_evaluator_runner.py
@@ -857,6 +857,9 @@ class TestConfirmContinue:
 
         Strict opt-in: only the literal string '1' enables auto-confirm.
         Prevents accidental opt-in from typo'd values like 'true', 'yes', etc.
+        Cancel notice should accurately report the actual env value rather
+        than claiming the var is unset (CodeRabbit/Bugbot follow-up on PR
+        movito/adversarial-workflow#69).
         """
         monkeypatch.setenv("ADVERSARIAL_UNATTENDED", "true")
         with (
@@ -869,6 +872,9 @@ class TestConfirmContinue:
             assert _confirm_continue() is False
         captured = capsys.readouterr()
         assert "auto-cancelling" in captured.out
+        # Notice must report the actual wrong value, not claim unset.
+        assert "'true'" in captured.out
+        assert "is unset" not in captured.out
 
 
 class TestBuiltinEvaluatorPath:

--- a/tests/test_evaluator_runner.py
+++ b/tests/test_evaluator_runner.py
@@ -852,9 +852,7 @@ class TestConfirmContinue:
         assert "auto-cancelling" in captured.out
         assert "ADVERSARIAL_UNATTENDED=1" in captured.out
 
-    def test_non_tty_with_unattended_other_value_auto_cancels(
-        self, capsys, monkeypatch
-    ):
+    def test_non_tty_with_unattended_other_value_auto_cancels(self, capsys, monkeypatch):
         """Non-TTY + ADVERSARIAL_UNATTENDED set to non-'1' value: still cancels.
 
         Strict opt-in: only the literal string '1' enables auto-confirm.

--- a/tests/test_evaluator_runner.py
+++ b/tests/test_evaluator_runner.py
@@ -757,37 +757,77 @@ class TestWarnLargeFile:
 
 
 class TestConfirmContinue:
-    """Direct tests for _confirm_continue helper (lines 320-321)."""
+    """Direct tests for _confirm_continue helper.
+
+    The non-TTY auto-yes guard (added 2026-04-29 in ADV follow-up to
+    ID2-0047) means every prompt-path test must also patch
+    ``sys.stdin.isatty`` to True, otherwise pytest captures stdin as
+    non-TTY and the helper short-circuits before ``input()`` is
+    consulted.
+    """
 
     def test_y_returns_true(self):
         """User typing 'y' means continue."""
-        with patch("builtins.input", return_value="y"):
+        with (
+            patch("sys.stdin.isatty", return_value=True),
+            patch("builtins.input", return_value="y"),
+        ):
             assert _confirm_continue() is True
 
     def test_yes_returns_true(self):
         """User typing 'yes' means continue."""
-        with patch("builtins.input", return_value="yes"):
+        with (
+            patch("sys.stdin.isatty", return_value=True),
+            patch("builtins.input", return_value="yes"),
+        ):
             assert _confirm_continue() is True
 
     def test_uppercase_y_returns_true(self):
         """User typing 'Y' (uppercase) is treated as yes after lower()."""
-        with patch("builtins.input", return_value="Y"):
+        with (
+            patch("sys.stdin.isatty", return_value=True),
+            patch("builtins.input", return_value="Y"),
+        ):
             assert _confirm_continue() is True
 
     def test_n_returns_false(self):
         """User typing 'n' means cancel."""
-        with patch("builtins.input", return_value="n"):
+        with (
+            patch("sys.stdin.isatty", return_value=True),
+            patch("builtins.input", return_value="n"),
+        ):
             assert _confirm_continue() is False
 
     def test_empty_returns_false(self):
         """Empty input (pressing Enter) defaults to No."""
-        with patch("builtins.input", return_value=""):
+        with (
+            patch("sys.stdin.isatty", return_value=True),
+            patch("builtins.input", return_value=""),
+        ):
             assert _confirm_continue() is False
 
     def test_arbitrary_text_returns_false(self):
         """Any other input defaults to No."""
-        with patch("builtins.input", return_value="maybe"):
+        with (
+            patch("sys.stdin.isatty", return_value=True),
+            patch("builtins.input", return_value="maybe"),
+        ):
             assert _confirm_continue() is False
+
+    def test_non_tty_auto_confirms(self, capsys):
+        """Non-TTY context: auto-confirm without prompting."""
+        with (
+            patch("sys.stdin.isatty", return_value=False),
+            # If we accidentally fall through to input(), this side_effect
+            # surfaces it as a clear test failure rather than a hang.
+            patch(
+                "builtins.input",
+                side_effect=AssertionError("input() should not be called in non-TTY"),
+            ),
+        ):
+            assert _confirm_continue() is True
+        captured = capsys.readouterr()
+        assert "Non-TTY" in captured.out or "auto-confirming" in captured.out
 
 
 class TestBuiltinEvaluatorPath:


### PR DESCRIPTION
## Summary

When a >700-line file is piped through `adversarial <evaluator>` from a
non-TTY context (CI runs, agentic harnesses, shell pipelines), the
previous behavior was to call `input("Continue anyway?")`, which raises
`EOFError` on a missing terminal and aborts the run.

This PR detects non-TTY via `sys.stdin.isatty()` and auto-confirms in
that case, printing a one-line notice so the behavior is observable.
Interactive (TTY) behavior is unchanged.

## Why

Discovered repeatedly while running adversarial evaluators from agentic
contexts in `movito/ixda-services-2.0`:

- ID2-0043 retro (Q1-2026 review-fix workflow)
- ID2-0046 retro (Round D — Modular Scale Recomposition)

In both cases, agents tried to evaluate large input files and hit
`EOFError` instead of getting an evaluation. The retros converged on
this single CLI fix.

Fixed cross-repo via `movito/ixda-services-2.0#11` (ID2-0047 Process
improvements bundle, Q2-2026 retro sweep).

## Test plan

- [x] `pytest tests/test_evaluator_runner.py -q` — 67 passed (existing
  + 1 new `test_non_tty_auto_confirms`)
- [x] `pytest tests/ -q` — 645 passed
- [x] Manual sanity check:
  ```bash
  seq 1 800 > /tmp/big.md
  echo "" | adversarial code-reviewer-fast /tmp/big.md
  # → "Non-TTY context detected — auto-confirming large input."
  # → proceeds to LLM call (no EOFError)
  ```

## Notes

- Existing prompt-path tests now also patch `sys.stdin.isatty=True` so
  they reach `input()` (otherwise pytest's captured stdin would
  short-circuit them through the new auto-yes path — a regression
  spotted while writing the new test).
- The `input()` mock in the new test uses `side_effect=AssertionError`
  to surface a regression as a clear test failure rather than a hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to CLI prompting behavior with good test coverage; main risk is altering default behavior for non-TTY runs (now cancels unless explicitly opted in).
> 
> **Overview**
> Updates the large-file confirmation flow in `evaluator` runs to detect non-TTY stdin and avoid calling `input()` when it would crash. In non-interactive contexts, runs now **auto-confirm only when `ADVERSARIAL_UNATTENDED=1` is set**, otherwise they **auto-cancel** with a clear printed notice; interactive TTY prompting is unchanged.
> 
> Expands tests around `_confirm_continue` to cover TTY vs non-TTY behavior and the new unattended opt-in/cancel paths, and adjusts existing prompt-path tests to patch `sys.stdin.isatty()` so they still reach `input()` under pytest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 038d4e7434d5caf211e829903dc9ae2e7d6726cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->